### PR TITLE
Added warning about delegated PN key security, and shellnet-testing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,15 @@ $WORKSPACE/
 └── giver/      GiverV3.abi.json — Shellnet funding artifact
 ```
 
-Use the notes two ways:
+Use the PNs two ways:
 
 - **directly with the SDK libraries** (`dodex-sdk` / `ackinacki-kit`) — sign on-chain operations with each note's key from its file;
 - **loaded into a running API service** — POST each `notes/<token>.account.json` to `/api/v1/accounts`.
+
+🚨 **Important:**
+Loading a PN into any API service delegates that PrivateNote's private key to the backend. 
+
+The hosted testing backend (`https://dodex-dev.ackinacki.org`) is for Shellnet testing only, **provides no security guarantees for delegated PN keys**, and will not be offered on Mainnet.
 
 Files under `multisig/` and `notes/` carry secret keys — back them up, never commit them.
 
@@ -49,6 +54,7 @@ Files under `multisig/` and `notes/` carry secret keys — back them up, never c
 - [docs/api-spec.md](docs/api-spec.md) — public REST API contract.
 - [docs/openapi.yaml](docs/openapi.yaml) — OpenAPI 3.1 contract, generated from the Rust handlers. See [openapi/README.md](openapi/README.md) for the regen workflow and the GitHub Pages deployment.
 - [docs/README.md](docs/README.md) — documentation map and file ownership.
+- [docs/shellnet-testing.md](docs/shellnet-testing.md) — tester guide for trying DEX.DO on Shellnet with the hosted testing backend or a self-hosted backend.
 - [docs/deployment.md](docs/deployment.md) — self-hosting the `indexer` and `api` on your own server, wired to your own Acki Nacki GraphQL endpoint and your own Postgres / Supabase.
 - [CONTRIBUTING.md](CONTRIBUTING.md) — where code and docs go (libs / services / tools), test and documentation rules, PR checklist. For humans and agents.
 - [AGENT_REQUIREMENTS.md](AGENT_REQUIREMENTS.md) — rules for any agent making repository changes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Operational cutover notes for specific schema/projector changes live in [migrati
 
 ## Operations
 
+- [shellnet-testing.md](shellnet-testing.md) — tester guide for trying DEX.DO on Shellnet with the hosted testing backend or a self-hosted backend, including Private Note key custody warnings.
 - [deployment.md](deployment.md) — self-hosting `indexer` + `api` with Docker Compose against your own Acki Nacki GraphQL endpoint and your own Postgres / Supabase.
 - [seed-private-notes.md](seed-private-notes.md) — seeding the api's trading accounts from a JSON notes file (config path, docker-compose delivery, KEK-derived API keys), and deploying/funding the PrivateNotes they point at.
 

--- a/docs/shellnet-testing.md
+++ b/docs/shellnet-testing.md
@@ -1,0 +1,105 @@
+# DEX.DO Shellnet Testing Guide
+
+To start testing DEX.DO in Shellnet, prepare your own test Private Notes,
+register them in the backend, and use the issued API keys for trading
+scenarios.
+
+## 1. Deploy Block Manager
+
+Deploy your own Block Manager (BM) instance using the Acki Nacki documentation:
+<https://github.com/ackinacki/ackinacki/blob/main/README.md#deployment-overview>
+
+During deployment, use the test BM license and BK endpoint provided to you.
+
+## 2. Deploy the DEX.DO backend
+
+Deploy a separate DEX.DO backend instance using this guide:
+
+<https://github.com/gosh-sh/dexdo/blob/dev/docs/deployment.md>
+
+For Shellnet testing, you can use the DEX.DO backend endpoint provided by the
+DEX.DO team: <https://dodex-dev.ackinacki.org>
+(DEX.DO will not offer this hosted-backend option on Mainnet.)
+
+**Important:** Loading a PN into any API service delegates the PrivateNote's
+private key to the backend and does not provide any security guarantees for
+delegated PN keys.
+
+Configure the backend to connect to your BM service and assigned BK endpoint.
+
+For self-service registration through `POST /api/v1/accounts`, keep
+`auth.seed_accounts` disabled (`false` or unset).
+
+## 3. Prepare Private Notes
+
+Testing requires pre-deployed and funded Private Notes (PNs). Each trading
+account works through a separate PN.
+
+Deploy a PN pool using the `mint_pn_pool` tool:
+<https://github.com/gosh-sh/dexdo/blob/dev/docs/seed-private-notes.md#producing-the-notes>
+
+Make sure each PN is funded with SHELL tokens. SHELL is used as gas for trading
+operations; a PN without SHELL cannot submit orders.
+
+Instructions for getting test SHELL and using the Shellnet giver:
+<https://dev.ackinacki.com/readme/get-test-tokens-in-shellnet#get-shell>
+
+The `pn_pool.json` and `pn_pool.seed_notes.json` files contain PN access data,
+including private keys. Do not commit them, do not publish them in logs, and
+share them only as secrets.
+
+For agent-driven Shellnet onboarding, see the root
+[`README.md`](../README.md#onboarding-shellnet).
+
+## 4. Register Trading Accounts
+
+For each PN, create one API account:
+
+```http
+POST /api/v1/accounts
+```
+
+Request body:
+
+```json
+{
+  "pnAddress": "<PN_address>",
+  "pnPubkeyHex": "<PN_pubkey_hex>",
+  "pnSeckeyHex": "<PN_seckey_hex>",
+  "pnDihHex": "<PN_dih_hex>"
+}
+```
+
+These fields can be taken from `pn_pool.seed_notes.json`. That file uses
+snake_case field names (`pn_address`, `pn_pubkey_hex`, `pn_seckey_hex`, and
+`pn_dih_hex`); the public API request uses camelCase field names.
+
+Endpoint documentation:
+<https://gosh-sh.github.io/dexdo/#tag/account/POST/api/v1/accounts>
+
+The backend checks that the PN exists on-chain and that the submitted private
+key matches the PN owner.
+
+The backend response returns `apiKey` and `apiSecret`.
+
+Store `apiKey` and `apiSecret` as secrets. The `apiSecret` is shown only during
+registration and is required for signed private and trading requests.
+
+Each PN can be registered once. If the backend returns a duplicate-registration
+error, use another PN or the credentials issued during the first registration.
+
+Full endpoint contract:
+[`api-spec.md#register-account`](api-spec.md#register-account).
+
+## 5. Start Testing the API
+
+After registering accounts, you can test trading scenarios through the DEX.DO
+API.
+
+- Public REST API contract: [`api-spec.md`](api-spec.md).
+- Generated OpenAPI contract: [`openapi.yaml`](openapi.yaml).
+- Published API docs: <https://gosh-sh.github.io/dexdo/>.
+
+Signed private and trading requests must include `X-DODEX-APIKEY`, `timestamp`,
+and `signature` as described in
+[`api-spec.md#security-types`](api-spec.md#security-types).

--- a/docs/shellnet-testing.md
+++ b/docs/shellnet-testing.md
@@ -1,36 +1,10 @@
 # DEX.DO Shellnet Testing Guide
 
 To start testing DEX.DO in Shellnet, prepare your own test Private Notes,
-register them in the backend, and use the issued API keys for trading
+choose a backend to register them, and use the issued API keys for trading
 scenarios.
 
-## 1. Deploy Block Manager
-
-Deploy your own Block Manager (BM) instance using the Acki Nacki documentation:
-<https://github.com/ackinacki/ackinacki/blob/main/README.md#deployment-overview>
-
-During deployment, use the test BM license and BK endpoint provided to you.
-
-## 2. Deploy the DEX.DO backend
-
-Deploy a separate DEX.DO backend instance using this guide:
-
-<https://github.com/gosh-sh/dexdo/blob/dev/docs/deployment.md>
-
-For Shellnet testing, you can use the DEX.DO backend endpoint provided by the
-DEX.DO team: <https://dodex-dev.ackinacki.org>
-(DEX.DO will not offer this hosted-backend option on Mainnet.)
-
-**Important:** Loading a PN into any API service delegates the PrivateNote's
-private key to the backend and does not provide any security guarantees for
-delegated PN keys.
-
-Configure the backend to connect to your BM service and assigned BK endpoint.
-
-For self-service registration through `POST /api/v1/accounts`, keep
-`auth.seed_accounts` disabled (`false` or unset).
-
-## 3. Prepare Private Notes
+## 1. Prepare Private Notes
 
 Testing requires pre-deployed and funded Private Notes (PNs). Each trading
 account works through a separate PN.
@@ -51,7 +25,40 @@ share them only as secrets.
 For agent-driven Shellnet onboarding, see the root
 [`README.md`](../README.md#onboarding-shellnet).
 
-## 4. Register Trading Accounts
+## 2. Choose a backend for PN registration
+
+DEX.DO testing requires a backend where your PNs will be registered. You can either use the hosted Shellnet backend provided by the DEX.DO team or deploy your own BM and DEX.DO backend instances.
+
+### Option 1: Use the hosted DEX.DO backend
+
+Use the DEX.DO backend endpoint provided by the DEX.DO team:
+<https://dodex-dev.ackinacki.org>.
+(DEX.DO will not offer this hosted-backend option on Mainnet)
+
+🚨 **Important:**
+Loading a PN into any API service **delegates **the PrivateNote's
+private key to the backend and does not provide any security guarantees for
+delegated PN keys**
+
+### Option 2: Deploy your own BM and DEX.DO backend
+
+Deploy your own Block Manager (BM) instance using the Acki Nacki documentation:
+<https://github.com/ackinacki/ackinacki/blob/main/README.md#deployment-overview>
+
+During BM deployment, use the test BM license and BK endpoint provided to you.
+
+Deploy a separate DEX.DO backend instance using this guide:
+
+<https://github.com/gosh-sh/dexdo/blob/dev/docs/deployment.md>
+
+Configure the backend to connect to your BM service and assigned BK endpoint.
+
+For self-service registration through `POST /api/v1/accounts` on your backend,
+keep `auth.seed_accounts` disabled (`false` or unset).
+
+## 3. Register Trading Accounts
+
+Use the backend selected in the previous step.
 
 For each PN, create one API account:
 
@@ -91,7 +98,7 @@ error, use another PN or the credentials issued during the first registration.
 Full endpoint contract:
 [`api-spec.md#register-account`](api-spec.md#register-account).
 
-## 5. Start Testing the API
+## 4. Start Testing the API
 
 After registering accounts, you can test trading scenarios through the DEX.DO
 API.


### PR DESCRIPTION
- Documented the hosted Shellnet DEX.DO backend endpoint: https://dodex-dev.ackinacki.org. 
- Added explicit custody warnings that registering a PN delegates `pnSeckeyHex` to the backend, which stores it and uses it for signing trading operations.
- Clarified that the hosted backend is Shellnet-only, provides no security guarantees for delegated PN keys, and will not be available on Mainnet.
- Added a canonical Shellnet tester guide at docs/shellnet-testing.md, and linked the new guide from README.md and docs/README.md.