### PR TITLE
dexdo total-withdraw skill + close/withdraw CLI subcommands + RPS notes

### DIFF
--- a/.claude/skills/dexdo-common/dexdo_client.py
+++ b/.claude/skills/dexdo-common/dexdo_client.py
@@ -161,6 +161,48 @@ def signed_request(args, method, path, query_params=None, body_obj=None):
 
 # --------------------------- command handlers ---------------------------
 
+def cmd_register(args):
+    """POST /api/v1/accounts (public): register a deployed note, get + store creds.
+
+    Reads the account body from --account-file (the onboarding `<tt>.account.json`),
+    POSTs it, and — on success — writes the returned credential to --save-creds with
+    owner-only perms (it carries the apiSecret, returned only once).
+    """
+    try:
+        with open(args.account_file) as fh:
+            body_obj = json.load(fh)
+    except (OSError, ValueError) as exc:
+        _fail(f"cannot read account file {args.account_file}: {exc}")
+    body_str = json.dumps(body_obj, separators=(",", ":"), ensure_ascii=False)
+    url = f"{args.base_url}/api/v1/accounts"
+    status, text = _request("POST", url, args.timeout,
+                            headers={"Content-Type": "application/json"},
+                            body_bytes=body_str.encode("utf-8"))
+    try:
+        parsed = json.loads(text)
+    except ValueError:
+        _emit(status, text)
+        return
+    print(json.dumps(parsed, indent=2, ensure_ascii=False))
+    if isinstance(parsed, dict) and parsed.get("apiSecret"):
+        if args.save_creds:
+            try:
+                fd = os.open(args.save_creds, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+                with os.fdopen(fd, "w") as fh:
+                    json.dump(parsed, fh, indent=2)
+                os.chmod(args.save_creds, 0o600)
+                sys.stderr.write(f"saved credential (0600) to {args.save_creds}\n")
+            except OSError as exc:
+                _fail(f"got credential but failed to save it to {args.save_creds}: {exc}")
+        else:
+            sys.stderr.write("WARNING: apiSecret is returned ONCE — capture it now "
+                             "(re-run with --save-creds <file> to store it)\n")
+        return
+    # error envelope (e.g. -2015 already registered, -2013 not deployed, -2016 wrong key)
+    if _is_error_envelope(parsed) or status >= 400:
+        sys.exit(1)
+
+
 def cmd_markets(args):
     params = [
         ("marketAddress", args.market_address),
@@ -333,6 +375,13 @@ def build_parser():
     p = argparse.ArgumentParser(
         description="DEX.DO REST client for agent skills (put options AFTER the subcommand)")
     sub = p.add_subparsers(dest="command", required=True)
+
+    sp = sub.add_parser("register", help="POST /api/v1/accounts (public) — register a note, get creds",
+                        parents=[common])
+    sp.add_argument("--account-file", required=True,
+                    help="path to the onboarding <tt>.account.json (the POST body)")
+    sp.add_argument("--save-creds", help="write the returned credential here (mode 0600)")
+    sp.set_defaults(func=cmd_register)
 
     sp = sub.add_parser("markets", help="GET /api/v1/markets (public)", parents=[common])
     sp.add_argument("--market-address")

--- a/.claude/skills/dexdo-deposit-shellnet/SKILL.md
+++ b/.claude/skills/dexdo-deposit-shellnet/SKILL.md
@@ -433,4 +433,11 @@ Three funded on-chain PrivateNotes (one per currency: SHELL / NACKL / USDC) unde
 - place/cancel orders in the outcome books;
 - claim payouts after a market resolves.
 
+**Next step to trade via the API:** the notes are deployed but **not yet registered**
+with the backend. To get API credentials (and use `dexdo-market-data` signed reads /
+`dexdo-trading` REST orders), register each note with the **`dexdo-register-account`**
+skill (`POST /api/v1/accounts` → `<tt>.creds.json`). That step is separate on purpose
+— it delegates the note's key to the backend. (The on-chain SDK path — `dexdo stake` /
+`place-order` — needs no registration; it signs with the note key directly.)
+
 All of this is covered by the **research / trading skills** built on top of this onboarding.

--- a/.claude/skills/dexdo-deposit-shellnet/SKILL.md
+++ b/.claude/skills/dexdo-deposit-shellnet/SKILL.md
@@ -70,6 +70,8 @@ Target layout after setup:
 
 `multisig/` and `notes/` are the universal layout (same on mainnet); `giver/` is network-specific (shellnet). Secrecy is per-file: recovery-critical are `Multisig.keys.json` and all `pn_state.*.json` (they go into the back-up checklist in Step 5); `*.abi.json`/`*.tvc` are disposable and re-downloadable.
 
+`pn_state.<tt>.json` and `<tt>.account.json` hold the note's **secret key** (`pnSeckeyHex`), so `onboard_user_shellnet` writes them **mode 0600** (owner-only). If you copy or regenerate them by other means, keep `0600` (`chmod 600 notes/*.json`) — never leave a note's key world-readable, and never commit these files.
+
 The dexdo SDK pulls `ackinacki-kit` as a git dependency (tag `v2.1.0`) — cargo clones the kit into its own cache at build time. We do **not** clone the kit locally: the three ABI/TVC artifacts are downloaded straight from `raw.githubusercontent` of that tag (Step 1).
 
 ### Setup 0.1 — Working directory

--- a/.claude/skills/dexdo-market-data/SKILL.md
+++ b/.claude/skills/dexdo-market-data/SKILL.md
@@ -49,7 +49,8 @@ with `--base-url` or `$DEXDO_BASE_URL`).
 The public views (markets, depth, price) need **no** credentials. "My open orders"
 and "my order history" are signed and need the account's API credential — the
 `<tt>.creds.json` file produced when the PrivateNote was registered
-(`POST /api/v1/accounts`; see the deposit/onboarding flow). Point the client at it:
+(`POST /api/v1/accounts` — produce it with the **`dexdo-register-account`** skill).
+Point the client at it:
 
 ```sh
 export DEXDO_CREDS="$HOME/dexdo-workspace/notes/nackl.creds.json"   # {apiKey, apiSecret}

--- a/.claude/skills/dexdo-register-account/SKILL.md
+++ b/.claude/skills/dexdo-register-account/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: dexdo-register-account
+description: Register a deployed-and-funded PrivateNote with the DEX.DO backend to get an API credential (apiKey + apiSecret) for the REST API. This is the bridge between onboarding (deploy/deposit a note on-chain) and using the API (signed reads in dexdo-market-data, REST orders in dexdo-trading). It is a deliberate security step — registering delegates the note's private key to the backend. Load when the user wants to "register my note / account", "get API keys", "connect my note to the API", or before any signed REST call when no creds.json exists yet.
+---
+
+# DEX.DO — Register Account (note → API credential)
+
+Turns a deployed PrivateNote into a usable API account: `POST /api/v1/accounts`
+returns an `apiKey` + `apiSecret`, stored as `<tt>.creds.json` (mode 0600). Those
+creds are what **`dexdo-market-data`** (signed reads) and **`dexdo-trading`** (REST
+orders) sign requests with.
+
+Where it sits in the flow:
+
+```
+dexdo-deploy-multisig  →  dexdo-deposit (note deployed + funded on-chain)
+                              │   produces notes/<tt>.account.json
+                              ▼
+                       dexdo-register-account   ← THIS skill (POST /accounts → creds.json)
+                              │
+                      ┌───────┴────────┐
+                      ▼                ▼
+              dexdo-market-data   dexdo-trading        →  dexdo-total-withdraw
+              (signed reads)      (REST orders)
+```
+
+> Registration is its **own** step on purpose — it is a security decision, not a
+> silent side-effect of depositing.
+
+## 🚨 Read before registering — what this actually does
+
+Registering **hands the note's private key to the backend** (the body includes
+`pnSeckeyHex`); the backend custodies it (sealed under its KEK) and signs your trades
+on your behalf. So:
+
+- Only register notes you're willing to let the backend trade with.
+- The hosted dev backend (`https://dodex-dev.ackinacki.org`) is **Shellnet testing
+  only, with no security guarantees for delegated keys**, and won't exist on Mainnet.
+- It is **one-shot per note**: a second registration of the same note returns `-2015`
+  (the original credential stays; no new one is minted). Losing an `apiSecret` can't
+  be undone by re-registering.
+
+Confirm with the user before registering — this is a deliberate, consequential action.
+
+## Preconditions
+
+- The note must be **deployed and funded on-chain** (the endpoint reads its on-chain
+  owner key before minting creds; an undeployed note → `-2013`). Run
+  `dexdo-deposit-shellnet` first if it isn't.
+- You need the note's `<tt>.account.json` (from onboarding) — it is the exact POST
+  body: `pnAddress`, `pnPubkeyHex`, `pnSeckeyHex`, `pnDihHex`.
+
+## Register
+
+Public endpoint (no auth — possession of the note's keys in the body is the
+capability). Driven by the shared client:
+
+```sh
+DEXDO="python3 $PWD/.claude/skills/dexdo-common/dexdo_client.py"   # from repo root
+export WORKSPACE="${WORKSPACE:-$HOME/dexdo-workspace}"
+
+$DEXDO register \
+  --account-file "$WORKSPACE/notes/<tt>.account.json" \
+  --save-creds   "$WORKSPACE/notes/<tt>.creds.json"
+# add --base-url https://your-host  to target a backend other than the dev default
+```
+
+On success it prints `{accountId, pnAddress, apiKey, apiSecret, permissions}` and
+writes `<tt>.creds.json` **mode 0600** (it holds the `apiSecret`, which the backend
+returns **only once**). That file is exactly what the read/trading skills consume via
+`--creds` / `$DEXDO_CREDS`.
+
+## Verify
+
+```sh
+$DEXDO account --creds "$WORKSPACE/notes/<tt>.creds.json"   # signed read should return balances
+```
+
+A `200` with balances confirms the credential works end-to-end (auth + signing).
+
+## Errors (map for the user)
+
+- `-2015` **already registered** — the note has a credential already; don't retry,
+  reuse the existing `creds.json`. (Not a failure to fix.)
+- `-2013` **note not deployed** on-chain — finish `dexdo-deposit-shellnet` first.
+- `-2016` **submitted key does not own the note** — wrong `account.json` for this note.
+- `-1130` malformed field (bad hex / pubkey≠seckey-derived). `-1500` transient backend
+  read — retry.
+
+## Scope / out of scope
+
+- **In:** register one deployed note → store its API credential (0600). With confirmation.
+- **Out:** deploying / funding the note (→ `dexdo-deposit-shellnet`); using the creds
+  to read or trade (→ `dexdo-market-data` / `dexdo-trading`). Registration is public
+  and unsigned, so it needs no existing credential.

--- a/.claude/skills/dexdo-total-withdraw/SKILL.md
+++ b/.claude/skills/dexdo-total-withdraw/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: dexdo-total-withdraw
+description: Close out a DEX.DO trading PrivateNote completely and sweep all funds back to the multisig wallet. Cancels every resting order, recovers stakes from still-open STAKING markets, merges held outcome tokens back into collateral (and claims resolved/cancelled markets), then withdraws all free collateral from the note to the multisig. Load when the user wants to "exit everything", "close all my positions and withdraw", "cash out", "total withdraw", or wind a note down before a network restart. Spends real funds and is destructive (drains the note) — confirms before the final withdraw.
+---
+
+# DEX.DO — Total Withdraw (close everything → sweep to multisig)
+
+Winds a trading PrivateNote all the way down and moves the funds back to the
+multisig. **All on-chain via the SDK** (the REST API does not expose stake/withdraw
+and its order path is flaky); driven by the **`dexdo`** SDK CLI.
+
+> **Why before a restart:** the season rules say funds not withdrawn before an
+> announced Shellnet restart can be lost. This skill is the "get everything back to
+> a wallet you control" button.
+
+Order matters — collateral is locked inside orders/stakes/positions, so you must
+**free it before sweeping**:
+
+1. **Cancel resting orders** (unlocks buy-side collateral)
+2. **Recover stakes** from still-open STAKING markets (cancel-stake) / **claim**
+   resolved or cancelled markets
+3. **Merge outcome tokens** back into collateral (merge-full-set)
+4. **Withdraw** all free collateral → multisig
+
+## Setup
+
+Uses the same `dexdo` SDK CLI and note state files as the trading/onboarding skills
+(build once per `dexdo-trading` §0):
+
+```sh
+export WORKSPACE="${WORKSPACE:-$HOME/dexdo-workspace}"
+DEXDO="$WORKSPACE/dexdo/sdk/target/release/dexdo"
+STATE="$WORKSPACE/notes/pn_state.<tt>.json"     # the note to drain (holds pn_address + owner key)
+CREDS="$WORKSPACE/notes/<tt>.creds.json"        # only for the read views below (REST)
+READ="python3 $PWD/.claude/skills/dexdo-common/dexdo_client.py"   # market-data client
+MULTISIG="0:<your-multisig-address>"            # destination (from the deploy skill)
+```
+
+Signing uses the note's own key from `pn_state.<tt>.json`. Reads use the
+`dexdo-market-data` skill.
+
+## Step 1 — Inventory what's open (so you know what to close)
+
+```sh
+"$DEXDO" stakes --pn-state-file "$STATE"                         # stakes per market (by eventId)
+$READ orders --creds "$CREDS"                                   # resting/open orders (all markets)
+$READ account --creds "$CREDS"                                  # quote-asset free vs locked
+$READ markets --status STAKING,TRADING,RESOLVING,RESOLVED,CANCELLED --limit 200   # phase per market
+```
+
+Map each `stakes` entry's `eventId`/`oracleListHash` to a market (via `markets`
+→ `event.eventId`) to get its `marketAddress` and `status`. Build the close-list:
+markets where you have **open orders**, **stakes**, or **outcome-token balances**
+(`$READ balances --market-address …`).
+
+## Step 2 — Cancel all resting orders (per market)
+
+```sh
+"$DEXDO" cancel-all-orders --market-address "0:<pmp>" --pn-state-file "$STATE"
+```
+
+Run once per market that has open orders. This frees the collateral locked in buy
+orders (and removes sell orders). Pace the calls (see *Pacing*).
+
+## Step 3 — Recover stakes / claim
+
+- **STAKING (still open):** recover the stake back to collateral —
+  ```sh
+  "$DEXDO" cancel-stake --market-address "0:<pmp>" --pn-state-file "$STATE"
+  ```
+- **RESOLVED / CANCELLED:** claim the payout / refund —
+  ```sh
+  "$DEXDO" claim --market-address "0:<pmp>" --pn-state-file "$STATE"
+  ```
+
+Pick per the market's `status` from Step 1. (`cancel-stake` only works while the
+market is still in its STAKING window; after that the position settles via `claim`
+once the market resolves.)
+
+## Step 4 — Merge outcome tokens back into collateral
+
+If `balances` shows outcome tokens on a market (e.g. from a full split or fills),
+merge them back. `--amounts` is a comma list of per-outcome amounts in order of
+`outcomeId` (use the per-outcome `free` from `$READ balances`):
+
+```sh
+"$DEXDO" merge-full-set --market-address "0:<pmp>" --pn-state-file "$STATE" --amounts 8.78,11.22
+```
+
+The contract merges the largest full set it can from those amounts and leaves the
+remainder; collateral returns to the note's free balance.
+
+## Step 5 — Withdraw everything to the multisig
+
+Once orders/stakes/positions are closed, sweep the note's **free** collateral to the
+multisig. `--dapp-id` defaults to the destination's account-id (a multisig deploys
+under its own account-id as dApp id); pass it explicitly only if different:
+
+```sh
+"$DEXDO" withdraw --pn-state-file "$STATE" --dest "$MULTISIG"
+```
+
+**Confirm with the user before this step** — it moves all the note's free funds out.
+`withdraw_tokens` sweeps the note's free balance of every token type to `--dest`.
+Anything still locked (an order/stake you didn't close) stays behind, so re-run
+Steps 2–4 for it and withdraw again.
+
+## Step 6 — Verify
+
+```sh
+$READ account --creds "$CREDS"                  # note should be ~0 free
+"$DEXDO" stakes --pn-state-file "$STATE"        # no remaining stakes
+tvm-cli -u shellnet.ackinacki.org account "${MULTISIG#0:}::${MULTISIG#0:}" | grep -E 'ecc|balance'  # multisig credited
+```
+
+The note's free balance should be ~0 and the multisig's `ecc` balance increased by
+the swept amount. Leftover locked balance ⇒ a position/order wasn't closed; repeat.
+
+## Pacing / errors (be gentle)
+
+Each step is an on-chain transaction (a network SEND) signed by the note. The network
+throttles **sends at >3 requests/second** → the Block Producer returns
+**`429 Too Many Requests`** (surfaced by the CLI as a `tvm` error, code 621). The
+limit is on **on-chain writes** (cancel / stake / merge / withdraw), **not** on the
+read views used to inventory (Step 1) — those you can call freely.
+
+So run the close/withdraw steps **one at a time, spaced a few seconds apart** (never
+in parallel); on a `429`, wait a few seconds and retry that one step (it's a
+throttle, not a rejection). Other real errors the SDK surfaces (vs the REST `-1000`):
+`exit 160` order/amount too small, `exit 129` invalid state for the op. A step that
+fails leaves the rest closeable — fix and continue; the flow is resumable.
+
+## Scope / out of scope
+
+- **In:** cancel orders, recover stakes, claim, merge full sets, withdraw a note's
+  collateral to the multisig — one note at a time, with confirmation before the sweep.
+- **Out:** opening positions / trading (→ `dexdo-trading`); reading data
+  (→ `dexdo-market-data`); moving funds off the multisig to an external wallet
+  (separate flow). Withdrawal to anything other than a wallet you control.

--- a/.claude/skills/dexdo-total-withdraw/SKILL.md
+++ b/.claude/skills/dexdo-total-withdraw/SKILL.md
@@ -102,8 +102,25 @@ under its own account-id as dApp id); pass it explicitly only if different:
 
 **Confirm with the user before this step** — it moves all the note's free funds out.
 `withdraw_tokens` sweeps the note's free balance of every token type to `--dest`.
-Anything still locked (an order/stake you didn't close) stays behind, so re-run
-Steps 2–4 for it and withdraw again.
+
+> **Hard precondition (contract invariant).** `PrivateNote.withdrawTokens` requires the
+> note to be **fully flat first**: `require(_stakes.empty())`, no open orders, nothing
+> `lockedInOrders`, no pending place/batch locks, and `_debt == 0`. If ANY stake or
+> order remains, the withdraw reverts on the compute phase (TVM **exit 121** /
+> `ERR_INVALID_STATE`-class) — it does **not** do a partial sweep. So Steps 2–4 must
+> clear **every** market the note touched, not just some.
+>
+> **The catch:** `cancel-stake` only works while a market is still in **STAKING**.
+> A stake in `AWAITING_FREEZE` / `TRADING` / `RESOLVING` can't be cancelled — it is
+> released only when the market reaches `RESOLVED`/`CANCELLED` and you **`claim`** it.
+> So if the note staked a market that has moved past STAKING and hasn't resolved yet,
+> **withdrawal is blocked until that market resolves** (then `claim`, then withdraw).
+> Enumerate with `dexdo stakes` + map each `eventId` to its market `status`; if any
+> are stuck mid-lifecycle, tell the user the sweep must wait for resolution.
+>
+> `--dapp-id` is a `uint256` — the CLI passes the destination's account-id **0x-prefixed**
+> by default (a bare hex account-id fails to parse as a decimal). Override only if the
+> wallet's real dApp id differs.
 
 ## Step 6 — Verify
 

--- a/.claude/skills/dexdo-total-withdraw/SKILL.md
+++ b/.claude/skills/dexdo-total-withdraw/SKILL.md
@@ -144,11 +144,25 @@ Tell the user plainly whether the sweep completed:
   (exit 121) until each resolves. **Show a table of exactly where the funds are stuck
   and when they free up — in the user's LOCAL time.**
 
-Build it from `dexdo stakes` (the stuck `eventId`s) joined to `markets`
-(`event.eventId` → `marketName`, `status`, `timings`). The unlock moment is when the
-market resolves: earliest at `timings.resultStart` (resolution window opens), and no
-later than `timings.resultEnd` (deadline → `EXPIRED`, then claimable). Convert those
-unix-seconds to the user's local time for display:
+Build it from `dexdo stakes` joined to `markets`. **Caveat (verified):** the top-level
+key in `dexdo stakes` is **not** the market's `event.eventId` — it is an opaque
+`tvm.hash(abi.encode(eventId, oracleListHash, tokenType))`, so you **cannot** join it
+to `markets` by `event.eventId`. Map each stake to its market instead by:
+
+- **what you staked** — in this same session you placed the stakes with
+  `dexdo stake --market-address … --outcome … --amount …`, so you already know each
+  stake's market; match on the `oracleListHash` + per-outcome `amount` shown in
+  `dexdo stakes` against those calls; **or**
+- **enumeration** — for each candidate market, pull `pmp-details` (`eventId`,
+  `oracleListHash`, `tokenType`) and recognise it by `oracleListHash` + the amounts.
+
+(Known gap to close: `dexdo stakes` should emit the resolved `marketAddress`/`status`
+per stake — it can't be reversed client-side from the hash key alone.)
+
+Once mapped, the unlock moment is when the market resolves: earliest at
+`timings.resultStart` (resolution window opens), and no later than `timings.resultEnd`
+(deadline → `EXPIRED`, then claimable). Convert those unix-seconds to the user's local
+time for display:
 
 ```sh
 # local time for a unix-seconds value (macOS/BSD: date -r ; GNU: date -d @)

--- a/.claude/skills/dexdo-total-withdraw/SKILL.md
+++ b/.claude/skills/dexdo-total-withdraw/SKILL.md
@@ -133,6 +133,41 @@ tvm-cli -u shellnet.ackinacki.org account "${MULTISIG#0:}::${MULTISIG#0:}" | gre
 The note's free balance should be ~0 and the multisig's `ecc` balance increased by
 the swept amount. Leftover locked balance ⇒ a position/order wasn't closed; repeat.
 
+## Step 7 — Report to the user (and the "stuck stakes" table)
+
+Tell the user plainly whether the sweep completed:
+
+- **Fully withdrawn:** note ~0, multisig credited — done.
+- **Blocked by stuck stakes:** the note still has stakes in markets that are **past
+  STAKING but not yet resolved** (`AWAITING_FREEZE` / `TRADING` / `RESOLVING`). These
+  can't be cancelled and can't be claimed yet, so `withdraw` will keep reverting
+  (exit 121) until each resolves. **Show a table of exactly where the funds are stuck
+  and when they free up — in the user's LOCAL time.**
+
+Build it from `dexdo stakes` (the stuck `eventId`s) joined to `markets`
+(`event.eventId` → `marketName`, `status`, `timings`). The unlock moment is when the
+market resolves: earliest at `timings.resultStart` (resolution window opens), and no
+later than `timings.resultEnd` (deadline → `EXPIRED`, then claimable). Convert those
+unix-seconds to the user's local time for display:
+
+```sh
+# local time for a unix-seconds value (macOS/BSD: date -r ; GNU: date -d @)
+date -r 1782310222 '+%Y-%m-%d %H:%M %Z' 2>/dev/null || date -d @1782310222 '+%Y-%m-%d %H:%M %Z'
+```
+
+Render, e.g.:
+
+| Market | Status | Your stake | Claimable from (local) | Hard deadline (local) |
+|---|---|---|---|---|
+| Group Stage — USA | RESOLVING | No 11.22 NACKL | 2026-06-25 09:30 CEST | 2026-06-26 09:30 CEST |
+| Rosengård W vs Djurgården | AWAITING_FREEZE | 0/1 split | 2026-06-25 12:00 CEST | 2026-06-26 12:00 CEST |
+
+Then state the next action: once a row reaches `RESOLVED`/`CANCELLED`, run
+`dexdo claim --market-address <that market> --pn-state-file "$STATE"`, and after the
+**last** stake clears, re-run `dexdo withdraw` to sweep the rest to the multisig.
+Reassure the user the funds are safe on the note in the meantime — nothing is lost,
+it's just time-locked by the market lifecycle.
+
 ## Pacing / errors (be gentle)
 
 Each step is an on-chain transaction (a network SEND) signed by the note. The network

--- a/.claude/skills/dexdo-trading/SKILL.md
+++ b/.claude/skills/dexdo-trading/SKILL.md
@@ -36,7 +36,8 @@ DEXDO="python3 $PWD/.claude/skills/dexdo-common/dexdo_client.py"   # from repo r
 ```
 
 Every endpoint here is `TRADE`-signed, so credentials are **required** — the
-account's `<tt>.creds.json` from registration (`POST /api/v1/accounts`):
+account's `<tt>.creds.json` from registration (`POST /api/v1/accounts`; produce it with
+the **`dexdo-register-account`** skill if it doesn't exist yet):
 
 ```sh
 export DEXDO_CREDS="$HOME/dexdo-workspace/notes/nackl.creds.json"

--- a/.claude/skills/dexdo-trading/SKILL.md
+++ b/.claude/skills/dexdo-trading/SKILL.md
@@ -245,6 +245,21 @@ post-restart deployment, but can lag under indexer backlog).
 (`DELETE /api/v1/openOrders` "cancel all on symbol", `sellFullSet`, and `claim` are
 in the draft spec but **not deployed** on dev — don't call them.)
 
+## Network rate limit (429) — pace on-chain SENDS
+
+The network throttles **message sends to the chain at >3 requests/second** → the
+Block Producer returns **`429 Too Many Requests`** (surfaced by the SDK CLI as a
+`tvm` error, code 621). This limit is on **on-chain writes — creating orders
+(`order` / `dexdo place-order`), stakes (`dexdo stake`), full splits, cancels** —
+**not** on reads (markets / depth / price / orders / stakes via `dexdo-market-data`,
+which you can call freely).
+
+So: **do not fire write ops in a burst.** Submit them **one at a time, spaced
+(~1s+ between sends is enough to stay under 3 rps; a few seconds is safer)**, and
+never run several order/stake commands in parallel. On a `429`, wait a few seconds
+and retry that one op — it's a throttle, not a rejection. (A single SDK write may
+itself issue a few chain queries, so leave margin rather than racing the limit.)
+
 ## Timeouts & retries
 
 Trade endpoints submit an on-chain transaction before responding and can take tens

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ On-chain contracts live under `contracts/`: the DEX.DO core in `contracts/dex/`,
 
 ## Onboarding (Shellnet)
 
-DEX.DO onboarding is **agent-driven**: an AI coding agent with shell access to this repo runs the flow from one-line prompts, split across two chained skills (deploy the multisig, then deposit / create PrivateNotes).
+DEX.DO is **agent-driven**: an AI coding agent with shell access to this repo runs the whole flow — onboarding, registration, market data, trading, and withdrawal — from one-line prompts, one per skill (see the [Quickstart](#quickstart--prompts-by-skill) below).
 
 **Prerequisites**
 
@@ -17,22 +17,29 @@ DEX.DO onboarding is **agent-driven**: an AI coding agent with shell access to t
 - macOS or Linux with `git`, `curl`, `jq` — the skill installs Rust (`cargo`) and `tvm-cli` itself if they're missing.
 - Network access to Shellnet (`shellnet.ackinacki.org`) and its public giver.
 
-Onboarding is split into two chained skills:
+## Quickstart — prompts by skill
 
-1. **Deploy the multisig** — [`.claude/skills/dexdo-deploy-multisig-shellnet/SKILL.md`](.claude/skills/dexdo-deploy-multisig-shellnet/SKILL.md): generate a 12-word seed + keypair, fund the precomputed address from the public giver, and deploy the wallet until it is Active.
-2. **Deposit / create PrivateNotes** — [`.claude/skills/dexdo-deposit-shellnet/SKILL.md`](.claude/skills/dexdo-deposit-shellnet/SKILL.md): takes the multisig as **input** (seed phrase *or* key pair), funds it with the deposit currencies, and deploys three gas-funded PrivateNotes (SHELL / NACKL / USDC).
+The whole lifecycle is driven by pasting one-line prompts to the agent. Each step maps
+to one skill under [`.claude/skills/`](.claude/skills/); run them top to bottom (skip
+any you've already done). Copy a prompt, fill in the `<…>` bits, paste.
 
-If you already have a multisig, run step 2 alone — supply its seed phrase or keypair.
+| # | Skill | Paste this prompt |
+|---|---|---|
+| 1 | [`dexdo-deploy-multisig-shellnet`](.claude/skills/dexdo-deploy-multisig-shellnet/SKILL.md) — deploy + fund a multisig | > Deploy and fund a multisig wallet for me on DEXDO Shellnet. |
+| 2 | [`dexdo-deposit-shellnet`](.claude/skills/dexdo-deposit-shellnet/SKILL.md) — fund the wallet + create PrivateNotes | > Deposit onto DEXDO Shellnet using my multisig (here is the seed phrase / keypair) — create three gas-funded PrivateNotes ready to trade. |
+| 3 | [`dexdo-register-account`](.claude/skills/dexdo-register-account/SKILL.md) — get API credentials (delegates the note key — opt-in) | > Register my PrivateNotes with the DEXDO API and save the credentials. |
+| 4 | [`dexdo-market-data`](.claude/skills/dexdo-market-data/SKILL.md) — read markets / book / price / my orders / my stakes | > Show me the active DEXDO markets I can stake or trade. <br> > Show the order book and price for `<symbol>`. <br> > Show my open orders / order history / stakes. |
+| 5 | [`dexdo-trading`](.claude/skills/dexdo-trading/SKILL.md) — stake / place orders / full split | > Stake `<amount>` NACKL on `<outcome>` in `<market>`. <br> > Place a limit `<BUY/SELL>` of `<qty>` `<symbol>` at `<price>`. <br> > Buy a full set in `<market>` for `<amount>` NACKL. |
+| 6 | [`dexdo-total-withdraw`](.claude/skills/dexdo-total-withdraw/SKILL.md) — close everything + sweep to multisig | > Close all my DEXDO positions and withdraw everything back to my multisig. |
 
-**Prompts** (paste into the agent):
+Notes:
 
-> Deploy and fund a multisig wallet for me on DEXDO Shellnet.
+- **Already have a multisig?** Skip step 1 — step 2 takes it as input (seed phrase or keypair).
+- **Steps 1–2 are on-chain only**; the note isn't usable via the API until **step 3** (registration is a deliberate security step — it delegates the note's key to the backend; see the warning below).
+- **Staking & the order book live in different market phases** — the trading skill (step 5) routes STAKING-phase stakes through the on-chain SDK and TRADING-phase orders through the REST API automatically.
+- **Before a network restart**, run step 6 to get funds back to the multisig (rewards not withdrawn in time can be lost).
 
-then, once it is Active:
-
-> Deposit onto DEXDO Shellnet using my multisig (here is the seed phrase / keypair) — create three gas-funded PrivateNotes ready to trade.
-
-**Output** — a multisig wallet you control and three funded PrivateNotes (SHELL / NACKL / USDC).
+**Output of steps 1–2** — a multisig wallet you control and three funded PrivateNotes (SHELL / NACKL / USDC).
 
 Everything is written under the workspace directory **`$WORKSPACE`** (default `~/dexdo-workspace`; export `WORKSPACE=/your/path` before running to change it):
 

--- a/README.md
+++ b/README.md
@@ -39,12 +39,21 @@ Everything is written under the workspace directory **`$WORKSPACE`** (default `~
 ```
 $WORKSPACE/
 ├── multisig/   wallet — Multisig.keys.json, Multisig.seed (SECRET) + Multisig.abi.json, Multisig.tvc
-├── notes/      two files per PrivateNote, token ∈ {shell, nackl, usdc} (SECRET):
+├── notes/      per-PrivateNote files, token ∈ {shell, nackl, usdc} (SECRET, mode 0600):
 │                 <token>.account.json  — ready POST /api/v1/accounts body
 │                                         (pnAddress / pnPubkeyHex / pnSeckeyHex / pnDihHex)
-│                 pn_state.<token>.json — onboarding resume state (not API-loadable)
+│                 pn_state.<token>.json — onboarding resume state, holds the note key (not API-loadable)
+│                 <token>.creds.json    — registration credential from POST /api/v1/accounts
+│                                         (apiKey + apiSecret); written only after you register the note
 └── giver/      GiverV3.abi.json — Shellnet funding artifact
 ```
+
+The `notes/` files hold two kinds of secret used by the trading / CLI skills:
+
+- **the note's on-chain key** (`pnSeckeyHex`, in `account.json` / `pn_state.json`) — signs on-chain ops (stake, place-order, withdraw) directly;
+- **the backend API credential** (`apiKey` + `apiSecret`, in `creds.json`) — obtained when you register the note (`POST /api/v1/accounts`); REST calls are then signed `HMAC-SHA256(request, apiSecret)` under the `X-DODEX-APIKEY` header, and the `apiSecret` is returned **only once** at registration.
+
+All of these are written **mode 0600** and stored in plaintext under `$WORKSPACE` — back them up, **never commit them**, and prefer an OS keychain over the workspace on an untrusted/multi-user host.
 
 Use the PNs two ways:
 

--- a/sdk/src/bin/dexdo.rs
+++ b/sdk/src/bin/dexdo.rs
@@ -390,9 +390,18 @@ async fn cmd_place_order(f: Flags) -> ExitCode {
     let decimals = match decimals_for(d.token_type) { Ok(v) => v, Err(e) => return fail(&e) };
     let amount = match parse_amount_to_raw(&amount_human, decimals) { Ok(v) => v, Err(e) => return fail(&e) };
     let price_bps = match price_to_bps(&price_human) { Ok(v) => v, Err(e) => return fail(&e) };
-    let client_order_id: u128 = f.get("client-id")
-        .and_then(|v| v.parse().ok())
-        .unwrap_or_else(|| now_unix() as u128);
+    if price_bps > 10_000 {
+        return fail(&format!("--price must be a probability in (0, 1] ({price_bps} bps > 10000)"));
+    }
+    // A bad --client-id must error, not silently fall back to a timestamp (that would
+    // place the order under an id the caller can't track / dedup a retry against).
+    let client_order_id: u128 = match f.get("client-id") {
+        Some(v) => match v.parse() {
+            Ok(n) => n,
+            Err(_) => return fail(&format!("--client-id must be a numeric u128, got `{v}`")),
+        },
+        None => now_unix() as u128,
+    };
 
     let (pn_address, keys) = match load_pn(&pn_state) { Ok(v) => v, Err(e) => return fail(&e) };
     eprintln!(
@@ -525,7 +534,12 @@ async fn cmd_merge_full_set(f: Flags) -> ExitCode {
     let mut amount: Vec<u128> = Vec::new();
     for part in amounts_csv.split(',') {
         let p = part.trim();
-        if p == "0" { amount.push(0); continue; }
+        // A zero per-outcome amount is legitimate (merge fewer outcomes); accept any
+        // spelling ("0", "0.0", "0.00"), which parse_amount_to_raw rejects as "> 0".
+        if p.parse::<f64>().map(|f| f == 0.0).unwrap_or(false) {
+            amount.push(0);
+            continue;
+        }
         match parse_amount_to_raw(p, decimals) {
             Ok(v) => amount.push(v),
             Err(e) => return fail(&format!("--amounts: {e}")),

--- a/sdk/src/bin/dexdo.rs
+++ b/sdk/src/bin/dexdo.rs
@@ -15,6 +15,7 @@
 //! Implemented subcommands:
 //!   stake        Stake on one outcome during the STAKING phase (PrivateNote.setStake).
 //!   stakes       Show a note's stakes across markets. (read-only)
+//!   place-order  Place an order via the SDK, bypassing REST (surfaces the real error).
 //!   pmp-details  Read a market's (PMP) phase, window, outcomes, identity. (read-only)
 //!
 //! Common flag: --endpoint <host>  (default shellnet.ackinacki.org)
@@ -32,7 +33,12 @@ use std::time::UNIX_EPOCH;
 
 use ackinacki_kit::tvm_client::abi::Signer;
 use ackinacki_kit::tvm_client::crypto::KeyPair;
+use dodex_contracts::dex::private_note::ParamsOfCancelAllOrders;
+use dodex_contracts::dex::private_note::ParamsOfMergeFullSet;
+use dodex_contracts::dex::private_note::ParamsOfPlaceOrder;
 use dodex_contracts::dex::private_note::ParamsOfSetStake;
+use dodex_contracts::dex::private_note::ParamsOfStakeKey;
+use dodex_contracts::dex::private_note::ParamsOfWithdrawTokens;
 use dodex_sdk::Dex;
 use dodex_sdk::DexConfig;
 use serde::Deserialize;
@@ -350,6 +356,78 @@ async fn cmd_pmp_details(f: Flags) -> ExitCode {
     ExitCode::SUCCESS
 }
 
+/// `dexdo place-order` — place an order on the order book DIRECTLY via the SDK
+/// (`PrivateNote.placeOrder`), bypassing the REST API. The REST `POST /order`
+/// masks chain failures as a generic `-1000`; this path surfaces the real error.
+/// price is a human probability 0..1 (converted to basis points); amount is the
+/// outcome-token quantity (scaled by token decimals). tif → flags:
+/// GTC=0, IOC=0x01, FOK=0x02, POST_ONLY=0x08.
+async fn cmd_place_order(f: Flags) -> ExitCode {
+    let market = match f.require("market-address") { Ok(v) => v.to_string(), Err(e) => return fail(&e) };
+    let pn_state = match f.require("pn-state-file") { Ok(v) => v.to_string(), Err(e) => return fail(&e) };
+    let outcome: u32 = match f.require("outcome").and_then(|v| v.parse().map_err(|_| format!("--outcome not a u32: {v}"))) {
+        Ok(v) => v, Err(e) => return fail(&e),
+    };
+    let side = match f.require("side") { Ok(v) => v.to_uppercase(), Err(e) => return fail(&e) };
+    let is_buy = match side.as_str() {
+        "BUY" => true, "SELL" => false,
+        other => return fail(&format!("--side must be BUY or SELL, got {other}")),
+    };
+    let price_human = match f.require("price") { Ok(v) => v.to_string(), Err(e) => return fail(&e) };
+    let amount_human = match f.require("amount") { Ok(v) => v.to_string(), Err(e) => return fail(&e) };
+    let flags: u8 = match f.get("tif").unwrap_or("GTC").to_uppercase().as_str() {
+        "GTC" => 0x00, "IOC" => 0x01, "FOK" => 0x02, "POST_ONLY" => 0x08,
+        other => return fail(&format!("--tif must be GTC|IOC|FOK|POST_ONLY, got {other}")),
+    };
+
+    let dex = match dex(&f.endpoint()) { Ok(d) => d, Err(e) => return fail(&e) };
+    let d = match dex.get_pmp_details(&market).await {
+        Ok(d) => d, Err(e) => return fail(&format!("get_pmp_details({market}) failed: {e:?}")),
+    };
+    if outcome >= d.num_outcomes {
+        return fail(&format!("outcome {} out of range ({} outcomes)", outcome, d.num_outcomes));
+    }
+    let decimals = match decimals_for(d.token_type) { Ok(v) => v, Err(e) => return fail(&e) };
+    let amount = match parse_amount_to_raw(&amount_human, decimals) { Ok(v) => v, Err(e) => return fail(&e) };
+    let price_bps = match price_to_bps(&price_human) { Ok(v) => v, Err(e) => return fail(&e) };
+    let client_order_id: u128 = f.get("client-id")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or_else(|| now_unix() as u128);
+
+    let (pn_address, keys) = match load_pn(&pn_state) { Ok(v) => v, Err(e) => return fail(&e) };
+    eprintln!(
+        "[dexdo place-order] {} {} {} outcome {} @ {} bps x {} (raw {}) flags=0x{:02x} on {} via {}",
+        side, token_label(d.token_type), if is_buy {"BUY"} else {"SELL"},
+        outcome, price_bps, amount_human, amount, flags, market, pn_address,
+    );
+    match dex.place_order(
+        &pn_address,
+        ParamsOfPlaceOrder {
+            event_id: d.event_id.clone(),
+            oracle_list_hash: d.oracle_list_hash.clone(),
+            token_type: d.token_type,
+            outcome_id: outcome,
+            is_buy,
+            price: price_bps.to_string(),
+            amount,
+            flags,
+            min_amount: 0,
+            epoch_id: 0,
+            client_order_id,
+        },
+        Signer::Keys { keys },
+    ).await {
+        Ok(res) => { println!("[dexdo place-order] DONE: {res:?}"); ExitCode::SUCCESS }
+        Err(e) => fail(&format!("place_order failed (REAL error, not the REST -1000): {e:?}")),
+    }
+}
+
+/// Human probability "0.30" → basis points (3000). tickSize 0.001 → 10 bps steps.
+fn price_to_bps(price: &str) -> Result<u64, String> {
+    let raw = parse_amount_to_raw(price, 4)?; // 4 dp == basis points
+    Ok(raw as u64)
+}
+
 /// `dexdo stakes` — show a note's stakes across markets (read-only).
 async fn cmd_stakes(f: Flags) -> ExitCode {
     let pn_address = match resolve_pn_address(&f) {
@@ -373,6 +451,128 @@ async fn cmd_stakes(f: Flags) -> ExitCode {
     }
 }
 
+/// `dexdo cancel-stake` — recover a stake from a still-open STAKING market.
+async fn cmd_cancel_stake(f: Flags) -> ExitCode {
+    stake_key_op(f, "cancel-stake").await
+}
+/// `dexdo claim` — settle/claim a RESOLVED or CANCELLED market.
+async fn cmd_claim(f: Flags) -> ExitCode {
+    stake_key_op(f, "claim").await
+}
+
+/// Shared body for the two `ParamsOfStakeKey` ops (cancel-stake / claim): both
+/// take {event_id, oracle_list_hash, token_type} read from the PMP on-chain.
+async fn stake_key_op(f: Flags, which: &str) -> ExitCode {
+    let market = match f.require("market-address") { Ok(v) => v.to_string(), Err(e) => return fail(&e) };
+    let pn_state = match f.require("pn-state-file") { Ok(v) => v.to_string(), Err(e) => return fail(&e) };
+    let dex = match dex(&f.endpoint()) { Ok(d) => d, Err(e) => return fail(&e) };
+    let d = match dex.get_pmp_details(&market).await {
+        Ok(d) => d, Err(e) => return fail(&format!("get_pmp_details({market}) failed: {e:?}")),
+    };
+    let (pn_address, keys) = match load_pn(&pn_state) { Ok(v) => v, Err(e) => return fail(&e) };
+    let key = ParamsOfStakeKey {
+        event_id: d.event_id.clone(),
+        oracle_list_hash: d.oracle_list_hash.clone(),
+        token_type: d.token_type,
+    };
+    eprintln!("[dexdo {which}] market {market} via note {pn_address}");
+    let res = if which == "claim" {
+        dex.claim(&pn_address, key, Signer::Keys { keys }).await
+    } else {
+        dex.cancel_stake(&pn_address, key, Signer::Keys { keys }).await
+    };
+    match res {
+        Ok(r) => { println!("[dexdo {which}] DONE: {r:?}"); ExitCode::SUCCESS }
+        Err(e) => fail(&format!("{which} failed: {e:?}")),
+    }
+}
+
+/// `dexdo cancel-all-orders` — cancel all the note's resting orders on one market.
+async fn cmd_cancel_all_orders(f: Flags) -> ExitCode {
+    let market = match f.require("market-address") { Ok(v) => v.to_string(), Err(e) => return fail(&e) };
+    let pn_state = match f.require("pn-state-file") { Ok(v) => v.to_string(), Err(e) => return fail(&e) };
+    let dex = match dex(&f.endpoint()) { Ok(d) => d, Err(e) => return fail(&e) };
+    let d = match dex.get_pmp_details(&market).await {
+        Ok(d) => d, Err(e) => return fail(&format!("get_pmp_details({market}) failed: {e:?}")),
+    };
+    let (pn_address, keys) = match load_pn(&pn_state) { Ok(v) => v, Err(e) => return fail(&e) };
+    eprintln!("[dexdo cancel-all-orders] market {market} via note {pn_address}");
+    match dex.cancel_all_orders(
+        &pn_address,
+        ParamsOfCancelAllOrders {
+            event_id: d.event_id.clone(),
+            oracle_list_hash: d.oracle_list_hash.clone(),
+            token_type: d.token_type,
+        },
+        Signer::Keys { keys },
+    ).await {
+        Ok(r) => { println!("[dexdo cancel-all-orders] DONE: {r:?}"); ExitCode::SUCCESS }
+        Err(e) => fail(&format!("cancel_all_orders failed: {e:?}")),
+    }
+}
+
+/// `dexdo merge-full-set` — merge held outcome tokens back into collateral on one
+/// market. `--amounts` is a comma list of per-outcome human amounts (order = outcomeId).
+async fn cmd_merge_full_set(f: Flags) -> ExitCode {
+    let market = match f.require("market-address") { Ok(v) => v.to_string(), Err(e) => return fail(&e) };
+    let pn_state = match f.require("pn-state-file") { Ok(v) => v.to_string(), Err(e) => return fail(&e) };
+    let amounts_csv = match f.require("amounts") { Ok(v) => v.to_string(), Err(e) => return fail(&e) };
+    let dex = match dex(&f.endpoint()) { Ok(d) => d, Err(e) => return fail(&e) };
+    let d = match dex.get_pmp_details(&market).await {
+        Ok(d) => d, Err(e) => return fail(&format!("get_pmp_details({market}) failed: {e:?}")),
+    };
+    let decimals = match decimals_for(d.token_type) { Ok(v) => v, Err(e) => return fail(&e) };
+    let mut amount: Vec<u128> = Vec::new();
+    for part in amounts_csv.split(',') {
+        let p = part.trim();
+        if p == "0" { amount.push(0); continue; }
+        match parse_amount_to_raw(p, decimals) {
+            Ok(v) => amount.push(v),
+            Err(e) => return fail(&format!("--amounts: {e}")),
+        }
+    }
+    if amount.len() as u32 != d.num_outcomes {
+        return fail(&format!("--amounts has {} entries but market has {} outcomes", amount.len(), d.num_outcomes));
+    }
+    let (pn_address, keys) = match load_pn(&pn_state) { Ok(v) => v, Err(e) => return fail(&e) };
+    eprintln!("[dexdo merge-full-set] {amount:?} on {market} via {pn_address}");
+    match dex.merge_full_set(
+        &pn_address,
+        ParamsOfMergeFullSet {
+            event_id: d.event_id.clone(),
+            oracle_list_hash: d.oracle_list_hash.clone(),
+            token_type: d.token_type,
+            amount,
+        },
+        Signer::Keys { keys },
+    ).await {
+        Ok(r) => { println!("[dexdo merge-full-set] DONE: {r:?}"); ExitCode::SUCCESS }
+        Err(e) => fail(&format!("merge_full_set failed: {e:?}")),
+    }
+}
+
+/// `dexdo withdraw` — sweep ALL the note's free collateral to a wallet (the
+/// multisig). Close positions/orders/stakes first so collateral is unlocked.
+async fn cmd_withdraw(f: Flags) -> ExitCode {
+    let pn_state = match f.require("pn-state-file") { Ok(v) => v.to_string(), Err(e) => return fail(&e) };
+    let dest = match f.require("dest") { Ok(v) => v.to_string(), Err(e) => return fail(&e) };
+    // dapp_id defaults to the destination's account-id (a multisig deploys under
+    // its own account-id as dapp_id); override with --dapp-id if different.
+    let dapp_id = f.get("dapp-id").map(|s| s.to_string())
+        .unwrap_or_else(|| dest.strip_prefix("0:").unwrap_or(&dest).to_string());
+    let (pn_address, keys) = match load_pn(&pn_state) { Ok(v) => v, Err(e) => return fail(&e) };
+    let dex = match dex(&f.endpoint()) { Ok(d) => d, Err(e) => return fail(&e) };
+    eprintln!("[dexdo withdraw] note {pn_address} → wallet {dest} (dapp_id {dapp_id})");
+    match dex.withdraw_tokens(
+        &pn_address,
+        ParamsOfWithdrawTokens { dest_wallet_addr: dest, dapp_id },
+        Signer::Keys { keys },
+    ).await {
+        Ok(r) => { println!("[dexdo withdraw] DONE: {r:?}"); ExitCode::SUCCESS }
+        Err(e) => fail(&format!("withdraw_tokens failed: {e:?}")),
+    }
+}
+
 // ----------------------------- dispatch -----------------------------
 
 fn fail(msg: &str) -> ExitCode {
@@ -389,6 +589,19 @@ fn usage() -> String {
        Stake on one outcome during the STAKING phase (PrivateNote.setStake).\n  \
        stakes        (--pn-state-file <path> | --pn-address 0:<pn>) [--endpoint host]\n                  \
        Show a note's stakes across markets (read-only).\n  \
+       place-order   --market-address 0:<pmp> --pn-state-file <path> --outcome <id> \
+     --side BUY|SELL --price <0..1> --amount <human> [--tif GTC|IOC|FOK|POST_ONLY]\n                  \
+       Place an order via the SDK (bypasses REST; shows the real chain error).\n  \
+       cancel-all-orders  --market-address 0:<pmp> --pn-state-file <path>\n                  \
+       Cancel all the note's resting orders on one market.\n  \
+       cancel-stake  --market-address 0:<pmp> --pn-state-file <path>\n                  \
+       Recover a stake from a still-open STAKING market.\n  \
+       merge-full-set  --market-address 0:<pmp> --pn-state-file <path> --amounts a,b[,..]\n                  \
+       Merge held outcome tokens back into collateral (per-outcome amounts).\n  \
+       claim         --market-address 0:<pmp> --pn-state-file <path>\n                  \
+       Settle/claim a RESOLVED or CANCELLED market.\n  \
+       withdraw      --pn-state-file <path> --dest 0:<multisig> [--dapp-id <id>]\n                  \
+       Sweep the note's free collateral to a wallet (the multisig).\n  \
        pmp-details   --market-address 0:<pmp> [--endpoint host]\n                  \
        Read a market's phase window, outcomes, and identity (read-only).\n\n\
      common flags:\n  \
@@ -404,6 +617,12 @@ async fn dispatch(sub: &str, rest: &[String]) -> ExitCode {
     match sub {
         "stake" => cmd_stake(flags).await,
         "stakes" => cmd_stakes(flags).await,
+        "place-order" => cmd_place_order(flags).await,
+        "cancel-all-orders" => cmd_cancel_all_orders(flags).await,
+        "cancel-stake" => cmd_cancel_stake(flags).await,
+        "merge-full-set" => cmd_merge_full_set(flags).await,
+        "claim" => cmd_claim(flags).await,
+        "withdraw" => cmd_withdraw(flags).await,
         "pmp-details" => cmd_pmp_details(flags).await,
         other => fail(&format!("unknown subcommand `{other}`\n\n{}", usage())),
     }

--- a/sdk/src/bin/dexdo.rs
+++ b/sdk/src/bin/dexdo.rs
@@ -558,8 +558,12 @@ async fn cmd_withdraw(f: Flags) -> ExitCode {
     let dest = match f.require("dest") { Ok(v) => v.to_string(), Err(e) => return fail(&e) };
     // dapp_id defaults to the destination's account-id (a multisig deploys under
     // its own account-id as dapp_id); override with --dapp-id if different.
-    let dapp_id = f.get("dapp-id").map(|s| s.to_string())
-        .unwrap_or_else(|| dest.strip_prefix("0:").unwrap_or(&dest).to_string());
+    // It is a uint256 — pass it 0x-prefixed so the ABI parses it as hex, not as a
+    // (failing) decimal of the bare account-id.
+    let dapp_id = f.get("dapp-id").map(|s| s.to_string()).unwrap_or_else(|| {
+        let bare = dest.strip_prefix("0:").unwrap_or(&dest);
+        if bare.starts_with("0x") { bare.to_string() } else { format!("0x{bare}") }
+    });
     let (pn_address, keys) = match load_pn(&pn_state) { Ok(v) => v, Err(e) => return fail(&e) };
     let dex = match dex(&f.endpoint()) { Ok(d) => d, Err(e) => return fail(&e) };
     eprintln!("[dexdo withdraw] note {pn_address} → wallet {dest} (dapp_id {dapp_id})");

--- a/sdk/src/bin/onboard_user_shellnet.rs
+++ b/sdk/src/bin/onboard_user_shellnet.rs
@@ -48,6 +48,7 @@
 //!
 //! Output file holds a secret — keep it private.
 
+use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::path::PathBuf;
@@ -317,9 +318,20 @@ fn write_account_file(state: &PnState, token_type: TokenTypeArg, state_path: &Pa
 /// These files (`<tt>.account.json`, `pn_state.<tt>.json`) carry `pnSeckeyHex`,
 /// so they must not be world-readable like a default `fs::write` (0644) leaves them.
 fn write_secret_file(path: &Path, json: &str) {
-    std::fs::write(path, json).expect("write secret file");
+    use std::io::Write;
+    // Create with 0600 from the start (no world-readable window), and also chmod
+    // before writing any bytes so a pre-existing looser file is locked down while
+    // still empty — the secret never lands on a 0644 file.
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)
+        .expect("open secret file");
     std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
         .expect("chmod 600 secret file");
+    f.write_all(json.as_bytes()).expect("write secret file");
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/sdk/src/bin/onboard_user_shellnet.rs
+++ b/sdk/src/bin/onboard_user_shellnet.rs
@@ -48,6 +48,7 @@
 //!
 //! Output file holds a secret — keep it private.
 
+use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::ExitCode;
@@ -308,8 +309,17 @@ fn write_account_file(state: &PnState, token_type: TokenTypeArg, state_path: &Pa
         state_path.parent().filter(|p| !p.as_os_str().is_empty()).unwrap_or_else(|| Path::new("."));
     let path = dir.join(format!("{}.account.json", token_type.label().to_ascii_lowercase()));
     let json = serde_json::to_string_pretty(&account).expect("serialize account file");
-    std::fs::write(&path, json).expect("write account file");
+    write_secret_file(&path, &json);
     eprintln!("[onboard] API-registration file: {}", path.display());
+}
+
+/// Write a file that holds the PN's secret key with owner-only perms (0600).
+/// These files (`<tt>.account.json`, `pn_state.<tt>.json`) carry `pnSeckeyHex`,
+/// so they must not be world-readable like a default `fs::write` (0644) leaves them.
+fn write_secret_file(path: &Path, json: &str) {
+    std::fs::write(path, json).expect("write secret file");
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+        .expect("chmod 600 secret file");
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -334,7 +344,8 @@ fn create_tvm_context(endpoint: &str) -> Arc<ClientContext> {
 
 fn save_state(state: &PnState, path: &Path) {
     let json = serde_json::to_string_pretty(state).expect("serialize state");
-    std::fs::write(path, json).expect("write state json");
+    // 0600 — the state file holds the note's secret key (owner_secret_key_hex).
+    write_secret_file(path, &json);
 }
 
 fn load_or_init_state(path: &Path, args: &Args) -> Result<PnState, String> {


### PR DESCRIPTION
Builds on #76 (dexdo SDK CLI, already in dev). Adds the wind-down flow + the chain rate-limit docs.

## Changes
- **`dexdo` CLI** new subcommands: `cancel-all-orders`, `cancel-stake`, `merge-full-set`, `claim`, `withdraw` (sweep the note's free collateral to the multisig). Still one CLI, more verbs.
- **New skill `dexdo-total-withdraw`**: inventory → cancel orders → recover stakes / claim → merge full sets → withdraw to multisig → verify.
- **RPS-limit note** in `dexdo-trading` and `dexdo-total-withdraw`: the network throttles **on-chain sends** (orders / stakes / cancels / withdraw) at **>3 req/s → 429**; reads are unaffected. Pace writes one-at-a-time; retry a 429.

Verified on shellnet: stake/place-order/pmp-details/stakes work; new close ops compile and reach the chain (cancel-stake hit the 429 throttle, confirming the rate limit — hence the docs).

Note: supersedes the now-dead `dexdo-stake-cli` branch (its CLI was squash-merged as #76).