### PR TITLE
Rename existing API to the /api/v1/prediction/ namespace

### DIFF
--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -6,8 +6,8 @@
     - [Signature Formation](#signature-formation)
   - [Error Response](#error-response)
   - [Endpoint Summary](#endpoint-summary)
-  - [Market Data Endpoints](#market-data-endpoints)
-    - [Markets](#markets)
+  - [Prediction Market Data](#prediction-market-data)
+    - [Prediction Markets](#prediction-markets)
       - [Common Enums](#common-enums)
         - [Market Status](#market-status)
       - [Common Objects](#common-objects)
@@ -16,22 +16,22 @@
           - [OracleEntry](#oracleentry)
         - [Terminal](#terminal)
         - [Outcome](#outcome)
-    - [Oracles](#oracles)
-      - [Oracle Data Objects](#oracle-data-objects)
-        - [OracleEntry](#oracleentry-1)
-        - [OracleEventList](#oracleeventlist)
-        - [OracleEvent](#oracleevent)
-        - [OracleOutcome](#oracleoutcome)
-    - [Order Book](#order-book)
-    - [Recent Trades](#recent-trades)
+    - [Prediction Order Book](#prediction-order-book)
+    - [Prediction Trades](#prediction-trades)
+  - [Oracles](#oracles)
+    - [Oracle Data Objects](#oracle-data-objects)
+      - [OracleEntry](#oracleentry-1)
+      - [OracleEventList](#oracleeventlist)
+      - [OracleEvent](#oracleevent)
+      - [OracleOutcome](#oracleoutcome)
   - [Account Endpoints](#account-endpoints)
     - [Account Balance](#account-balance)
     - [Market Outcome Balances](#market-outcome-balances)
-  - [Position Endpoints](#position-endpoints)
+  - [Prediction Position Endpoints](#prediction-position-endpoints)
     - [Buy Full Set](#buy-full-set)
     - [Sell Full Set](#sell-full-set)
     - [Claim](#claim)
-  - [Trading Endpoints](#trading-endpoints)
+  - [Prediction Trading Endpoints](#prediction-trading-endpoints)
     - [New Order](#new-order)
     - [Cancel Order](#cancel-order)
     - [New Batch Orders](#new-batch-orders)
@@ -43,7 +43,7 @@
       - [Order Type](#order-type)
       - [Time In Force](#time-in-force)
       - [Order Status](#order-status)
-  - [WebSocket Streams](#websocket-streams)
+  - [Prediction WebSocket Streams](#prediction-websocket-streams)
     - [Connection](#connection)
     - [Splice and Gap Detection](#splice-and-gap-detection)
     - [Order Updates](#order-updates)
@@ -88,18 +88,18 @@ floating-point precision loss.
 
 DEX.DO uses the following market identifiers:
 
-- `marketAddress` is the stable market identifier across the entire lifecycle. Used in all market-specific requests. Example: `0:market-address`.
-- `orderBookAddress` is the deterministic order-book address returned by `/api/v1/markets`. It is always present on any market that appears in API responses — the backend stamps it on the first reconcile, before the OrderBook contract is active on-chain. The only state where it can be null internally is the pre-reconcile window, and such markets are hidden from the API. Clients MUST use `status` to determine whether the order book is currently available for trading; a non-null `orderBookAddress` does not by itself imply the book is open.
+- `predictionMarketAddress` is the stable market identifier across the entire lifecycle. Used in all market-specific requests. Example: `0:market-address`.
+- `predictionOrderBookAddress` is the deterministic order-book address returned by `/api/v1/prediction/markets`. It is always present on any market that appears in API responses — the backend stamps it on the first reconcile, before the OrderBook contract is active on-chain. The only state where it can be null internally is the pre-reconcile window, and such markets are hidden from the API. Clients MUST use `status` to determine whether the order book is currently available for trading; a non-null `predictionOrderBookAddress` does not by itself imply the book is open.
 - `marketName` is the market name. Example: `PM-2026-ELECTION`.
 - `symbol` is the outcome-token symbol and is formed as `<marketName>-<OUTCOME_NAME>`. Example: `PM-2026-ELECTION-YES`.
 
-Requests that target one order book use `marketAddress` and `symbol`.
+Requests that target one order book use `predictionMarketAddress` and `symbol`.
 Responses return the same identifiers where relevant.
 
 Examples:
 
 ```text
-marketAddress = 0:market-address
+predictionMarketAddress = 0:market-address
 marketName    = PM-2026-ELECTION
 symbol        = PM-2026-ELECTION-YES
 ```
@@ -144,14 +144,14 @@ Formula:
 signature = HMAC_SHA256(canonicalQueryString + canonicalRequestBody, apiSecret)
 ```
 
-Example for `POST /api/v1/order`:
+Example for `POST /api/v1/prediction/order`:
 
 ```text
 canonicalQueryString = recvWindow=5000&timestamp=1710000000000
-canonicalRequestBody = {"marketAddress":"0:market-address","symbol":"PM-2026-ELECTION-YES","side":"BUY","quantity":"1.500000","price":"0.615","type":"LIMIT","timeInForce":"GTC"}
+canonicalRequestBody = {"predictionMarketAddress":"0:market-address","symbol":"PM-2026-ELECTION-YES","side":"BUY","quantity":"1.500000","price":"0.615","type":"LIMIT","timeInForce":"GTC"}
 
 signature = HMAC_SHA256(
-  'recvWindow=5000&timestamp=1710000000000{"marketAddress":"0:market-address","symbol":"PM-2026-ELECTION-YES","side":"BUY","quantity":"1.500000","price":"0.615","type":"LIMIT","timeInForce":"GTC"}',
+  'recvWindow=5000&timestamp=1710000000000{"predictionMarketAddress":"0:market-address","symbol":"PM-2026-ELECTION-YES","side":"BUY","quantity":"1.500000","price":"0.615","type":"LIMIT","timeInForce":"GTC"}',
   apiSecret
 )
 ```
@@ -190,11 +190,11 @@ Recommended common error codes:
 | `-2015` | Private note already registered. | 409 |
 | `-2016` | Submitted key does not control this private note. | 400 |
 
-`-1007` means the request did not complete in time. The order may still have been accepted by the exchange. Retry `POST /api/v1/order` with the same `newOrderClientId` — the server will deduplicate so the same order is not placed twice.
+`-1007` means the request did not complete in time. The order may still have been accepted by the exchange. Retry `POST /api/v1/prediction/order` with the same `newOrderClientId` — the server will deduplicate so the same order is not placed twice.
 
 `-2013` means the caller's authenticated account has no PrivateNote contract deployed at its resolved address. The credential is valid but the on-chain contract is missing; the client should offer "deploy your account" instead of retrying.
 
-`-2014` means another order from the same account is still being processed. Retry after a short delay; the in-flight order will appear in `/api/v1/orders` shortly.
+`-2014` means another order from the same account is still being processed. Retry after a short delay; the in-flight order will appear in `/api/v1/prediction/orders` shortly.
 
 `-2015` means `POST /api/v1/accounts` was called for a PrivateNote that already has an account. Registration is one-shot per note: the existing credential is left untouched and no new one is minted. Do not retry — use the credential issued at first registration.
 
@@ -212,43 +212,43 @@ envelope field failed or why a credential was rejected.
 
 | Function | Method | Path | Security |
 | --- | --- | --- | --- |
-| List markets | `GET` | `/api/v1/markets` | `NONE` |
+| List prediction markets | `GET` | `/api/v1/prediction/markets` | `NONE` |
 | List oracles and their available events | `GET` | `/api/v1/oracles` | `NONE` |
-| Fetch order book | `GET` | `/api/v1/depth` | `NONE` |
-| Fetch recent trades | `GET` | `/api/v1/trades` | `NONE` |
+| Fetch prediction order book | `GET` | `/api/v1/prediction/depth` | `NONE` |
+| Fetch recent prediction trades | `GET` | `/api/v1/prediction/trades` | `NONE` |
 | Register a trading account from a PrivateNote | `POST` | `/api/v1/accounts` | `NONE` |
 | Fetch account collateral balance | `GET` | `/api/v1/account` | `USER_DATA` |
 | Fetch outcome balances for one market | `GET` | `/api/v1/account/balances` | `USER_DATA` |
-| Buy a full set of outcome tokens with collateral | `POST` | `/api/v1/buyFullSet` | `TRADE` |
-| Sell a full set of outcome tokens back into collateral | `POST` | `/api/v1/sellFullSet` | `TRADE` |
-| Claim payout after market resolution | `POST` | `/api/v1/claim` | `TRADE` |
-| Create single order | `POST` | `/api/v1/order` | `TRADE` |
-| Cancel single order by ID | `DELETE` | `/api/v1/order` | `TRADE` |
-| Create batch orders | `POST` | `/api/v1/batchOrders` | `TRADE` |
-| Cancel batch orders by IDs | `DELETE` | `/api/v1/batchOrders` | `TRADE` |
-| Cancel all open orders on one symbol | `DELETE` | `/api/v1/openOrders` | `TRADE` |
-| Fetch orders | `GET` | `/api/v1/orders` | `USER_DATA` |
-| Subscribe to user order updates | `WS` | `/ws/v1/user` | `USER_DATA` |
+| Buy a full set of outcome tokens with collateral | `POST` | `/api/v1/prediction/buyFullSet` | `TRADE` |
+| Sell a full set of outcome tokens back into collateral | `POST` | `/api/v1/prediction/sellFullSet` | `TRADE` |
+| Claim payout after market resolution | `POST` | `/api/v1/prediction/claim` | `TRADE` |
+| Create single order | `POST` | `/api/v1/prediction/order` | `TRADE` |
+| Cancel single order by ID | `DELETE` | `/api/v1/prediction/order` | `TRADE` |
+| Create batch orders | `POST` | `/api/v1/prediction/batchOrders` | `TRADE` |
+| Cancel batch orders by IDs | `DELETE` | `/api/v1/prediction/batchOrders` | `TRADE` |
+| Cancel all open orders on one symbol | `DELETE` | `/api/v1/prediction/openOrders` | `TRADE` |
+| Fetch orders | `GET` | `/api/v1/prediction/orders` | `USER_DATA` |
+| Subscribe to user order updates | `WS` | `/ws/v1/prediction/user` | `USER_DATA` |
 
-## Market Data Endpoints
+## Prediction Market Data
 
-### Markets
+### Prediction Markets
 
 ```http
-GET /api/v1/markets
+GET /api/v1/prediction/markets
 ```
 
 Fetch available prediction markets, their outcomes, lifecycle phase, timings, and oracle event metadata.
 
 A market in DEX.DO has a finite lifecycle anchored to an oracle event. The lifecycle has nine phases — see [Market Status](#market-status). Clients MUST treat `status` as an opaque enum value and not derive it from raw timings.
 
-In `/api/v1/markets`, `event.oracles[]` contains only the oracles for that market. Use `/api/v1/oracles` to list oracles and events available for creating markets.
+In `/api/v1/prediction/markets`, `event.oracles[]` contains only the oracles for that market. Use `/api/v1/oracles` to list oracles and events available for creating markets.
 
 Query parameters:
 
 | Name | Type | Mandatory | Description |
 | --- | --- | --- | --- |
-| `marketAddress` | STRING | NO | Return one market only. Mutually exclusive with the filter and pagination parameters below. |
+| `predictionMarketAddress` | STRING | NO | Return one market only. Mutually exclusive with the filter and pagination parameters below. |
 | `status` | STRING | NO | Comma-separated list of statuses to include. Example: `TRADING,AWAITING_FREEZE`. |
 | `quoteAsset` | STRING | NO | Filter by quote asset. Example: `USDC`. |
 | `oracleName` | STRING | NO | Filter by oracle name. A market matches if its `event.oracles[]` contains this oracle name. |
@@ -266,8 +266,8 @@ Response:
   "hasMore": false,
   "markets": [
     {
-      "marketAddress": "0:b286...",
-      "orderBookAddress": "0:c12d...",
+      "predictionMarketAddress": "0:b286...",
+      "predictionOrderBookAddress": "0:c12d...",
       "marketName": "PM-2026-ELECTION",
       "status": "TRADING",
       "quoteAsset": "USDC",
@@ -326,11 +326,11 @@ Response fields:
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `serverTime` | LONG | Unix timestamp in seconds. All timestamp fields returned by `/api/v1/markets` are unix seconds unless explicitly stated otherwise. |
+| `serverTime` | LONG | Unix timestamp in seconds. All timestamp fields returned by `/api/v1/prediction/markets` are unix seconds unless explicitly stated otherwise. |
 | `nextCursor` | STRING \| null | Pagination cursor for the next page. `null` when `hasMore` is `false`. |
 | `hasMore` | BOOLEAN | Whether more pages follow. |
-| `marketAddress` | STRING | Stable market identifier. |
-| `orderBookAddress` | STRING | Deterministic order-book address. Always present on markets visible to the API (the backend stamps it on the first reconcile). Trading availability depends on market `status`. |
+| `predictionMarketAddress` | STRING | Stable market identifier. |
+| `predictionOrderBookAddress` | STRING | Deterministic order-book address. Always present on markets visible to the API (the backend stamps it on the first reconcile). Trading availability depends on market `status`. |
 | `marketName` | STRING | Technical market name. Not the user-facing title; see `event.eventName`. |
 | `status` | ENUM | Market phase. See [Market Status](#market-status). |
 | `quoteAsset` | STRING | Quote-asset symbol for display. |
@@ -503,7 +503,140 @@ Example for a non-terminal market (any of the six live statuses, including the t
 | `minNotional` | DECIMAL | Minimum accepted notional value for an order. |
 | `maxBatchSize` | INT | Maximum number of orders accepted in one batch request for this outcome. |
 
-### Oracles
+### Prediction Order Book
+
+```http
+GET /api/v1/prediction/depth
+```
+
+Fetch bids and asks for one symbol in one market.
+
+Query parameters:
+
+| Name | Type | Mandatory | Description |
+| --- | --- | --- | --- |
+| `predictionMarketAddress` | STRING | YES | Market address. Example: `0:market-address`. |
+| `symbol` | STRING | YES | Outcome-token symbol. Example: `PM-2026-ELECTION-YES`. |
+| `limit` | INT | NO | Number of price levels per side. Default: `100`. Max: `1000`. |
+
+Response:
+
+```json
+{
+  "predictionMarketAddress": "0:market-address",
+  "symbol": "PM-2026-ELECTION-YES",
+  "lastUpdateId": "76a23086a00670000000000000000000000000000000000000000000000000000000000000000000002",
+  "bids": [
+    ["0.614", "100.00"],
+    ["0.613", "25.50"]
+  ],
+  "asks": [
+    ["0.616", "50.00"],
+    ["0.617", "75.25"]
+  ]
+}
+```
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `lastUpdateId` | STRING | Opaque chain-order cursor. Lex-comparable: a larger string means a newer event has touched this `(predictionMarketAddress, symbol)`. Empty string when no order event has landed yet. Clients SHOULD compare for equality to detect "no change" and string-lex order to detect "moved forward"; they SHOULD NOT parse it as an integer. |
+
+Each bid or ask item is:
+
+```text
+[price, quantity]
+```
+
+### Prediction Trades
+
+```http
+GET /api/v1/prediction/trades
+```
+
+Security: `NONE`
+
+Fetch the most recent public trades for one symbol in one market. A trade is a
+single maker↔taker match produced by the order book — the public, account-agnostic
+view of the fills that surface privately as `x: "TRADE"` frames on the
+[`orderUpdate`](#order-updates) WebSocket stream. No authentication is required and
+no owner information is returned; the endpoint exposes only price, size, direction,
+and time.
+
+This endpoint is unaffected by market lifecycle status: trades are returned for any
+market that has been reconciled at least once, including terminal phases
+(`RESOLVED`, `CANCELLED`, `EXPIRED`), so the trade tape remains readable after the
+book closes. It is eventually consistent — a just-matched trade may briefly lag the
+fill that produced it until the indexer projects the match.
+
+Query parameters:
+
+| Name | Type | Mandatory | Description |
+| --- | --- | --- | --- |
+| `predictionMarketAddress` | STRING | YES | Market address. Example: `0:market-address`. |
+| `symbol` | STRING | YES | Outcome-token symbol. Example: `PM-2026-ELECTION-YES`. |
+| `limit` | INT | NO | Number of trades to return, newest first. Default: `20`. Max: `1000`. |
+
+Response:
+
+```json
+[
+  {
+    "tradeId": "76a23086a00670000000000000000000000000000000000000000000000000000000000000000000005",
+    "price": "0.615",
+    "qty": "1.00",
+    "quoteQty": "0.615000",
+    "time": 1710000008980,
+    "isBuyerMaker": true
+  },
+  {
+    "tradeId": "76a23086a00670000000000000000000000000000000000000000000000000000000000000000000004",
+    "price": "0.615",
+    "qty": "0.50",
+    "quoteQty": "0.307500",
+    "time": 1710000004980,
+    "isBuyerMaker": true
+  }
+]
+```
+
+The response is a bare JSON array, newest trade first, ordered by the same
+server-internal chain-order key used by [`GET /api/v1/prediction/orders`](#orders) (descending).
+An empty array means no trade has matched on this symbol yet.
+
+Trade fields:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `tradeId` | STRING | Opaque, lex-comparable id for one maker↔taker match. The identical value is carried by the WebSocket [`orderUpdate`](#order-updates) fill frame as field `t`, on both sides of the match — so a client can correlate a public trade with its own private fills and deduplicate across the two feeds. Treat it as an opaque token; do not parse it. |
+| `price` | DECIMAL | Match (clearing) price, scaled by the outcome price precision. |
+| `qty` | DECIMAL | Matched outcome-token quantity, scaled by the outcome quantity precision. |
+| `quoteQty` | DECIMAL | Quote-asset notional of the match (`price × qty`), scaled by the quote asset's on-chain `decimals`. |
+| `time` | LONG | On-chain match time in Unix milliseconds, truncated from the indexed microsecond timestamp — same convention as `time` / `updateTime` on [`GET /api/v1/prediction/orders`](#orders). |
+| `isBuyerMaker` | BOOLEAN | `true` when the resting (maker) side was the buy order and the taker was selling; `false` when the taker was buying. Determines display direction: `true` = taker sold (downtick), `false` = taker bought (uptick). Matches Binance `isBuyerMaker` semantics. |
+
+Each public trade is the account-agnostic view of a fill that also appears on the
+private [`orderUpdate`](#order-updates) stream (`x: "TRADE"`). The fields line up
+one-to-one, so a client subscribed to both feeds can match them by `tradeId` / `t`:
+
+| `/api/v1/prediction/trades` field | `orderUpdate` fill field | Note |
+| --- | --- | --- |
+| `tradeId` | `t` | Same opaque match id on both feeds, and on both sides of the match. |
+| `price` | `L` | Last fill price. |
+| `qty` | `l` | Last fill quantity. |
+| `time` | `T` | On-chain match / transaction time. |
+| `isBuyerMaker` | `S` + `m` | Public trade carries the side-agnostic direction; the `orderUpdate` frame carries the recipient's own side (`S`) and maker flag (`m`). |
+
+Errors:
+
+| Condition | Code | HTTP |
+| --- | --- | --- |
+| `predictionMarketAddress` or `symbol` missing or blank | `-1102` | 400 |
+| `limit` present but not an integer | `-1130` | 400 |
+| `limit` outside `[1, 1000]` | `-1102` | 400 |
+| `(predictionMarketAddress, symbol)` pair not found, or its market has not been reconciled yet | `-1121` | 404 |
+| Trade data is temporarily inconsistent | `-1500` | 503 |
+
+## Oracles
 
 ```http
 GET /api/v1/oracles
@@ -513,7 +646,7 @@ Fetch oracles, their event lists, and events that can be used to create a market
 
 The response is grouped by oracle, then by event list. Each event list contains its description and the events it currently offers for market creation.
 
-This endpoint does not return markets already created from these events. Use `/api/v1/markets` for market lifecycle, status, timings, order-book address, and market outcomes.
+This endpoint does not return markets already created from these events. Use `/api/v1/prediction/markets` for market lifecycle, status, timings, order-book address, and market outcomes.
 
 By default, each event list includes only events that are still available for new markets: not deleted and not past `deadline`.
 
@@ -599,9 +732,9 @@ Response fields:
 | `oracles[].eventLists[].events[].trustAddress` | STRING \| null | Optional trusted address attached to the event. `null` when absent or unavailable. |
 | `oracles[].eventLists[].events[].outcomes` | ARRAY of [OracleOutcome](#oracleoutcome) | Event outcome labels, sorted by `outcomeId`. |
 
-#### Oracle Data Objects
+### Oracle Data Objects
 
-##### OracleEntry
+#### OracleEntry
 
 ```json
 {
@@ -624,7 +757,7 @@ Response fields:
 | `address` | STRING | Oracle address. |
 | `eventLists` | ARRAY of [OracleEventList](#oracleeventlist) | Event lists owned by this oracle. |
 
-##### OracleEventList
+#### OracleEventList
 
 | Field | Type | Description |
 | --- | --- | --- |
@@ -633,7 +766,7 @@ Response fields:
 | `description` | STRING | Human-readable event-list description. |
 | `events` | ARRAY of [OracleEvent](#oracleevent) | Events offered by this event list. |
 
-##### OracleEvent
+#### OracleEvent
 
 | Field | Type | Description |
 | --- | --- | --- |
@@ -647,145 +780,12 @@ Response fields:
 | `trustAddress` | STRING \| null | Optional trusted address attached to the event. `null` when absent or unavailable. |
 | `outcomes` | ARRAY of [OracleOutcome](#oracleoutcome) | Event outcome labels, sorted by `outcomeId`. |
 
-##### OracleOutcome
+#### OracleOutcome
 
 | Field | Type | Description |
 | --- | --- | --- |
 | `outcomeId` | INT | Outcome id. |
 | `outcomeName` | STRING | Human-readable outcome label. |
-
-### Order Book
-
-```http
-GET /api/v1/depth
-```
-
-Fetch bids and asks for one symbol in one market.
-
-Query parameters:
-
-| Name | Type | Mandatory | Description |
-| --- | --- | --- | --- |
-| `marketAddress` | STRING | YES | Market address. Example: `0:market-address`. |
-| `symbol` | STRING | YES | Outcome-token symbol. Example: `PM-2026-ELECTION-YES`. |
-| `limit` | INT | NO | Number of price levels per side. Default: `100`. Max: `1000`. |
-
-Response:
-
-```json
-{
-  "marketAddress": "0:market-address",
-  "symbol": "PM-2026-ELECTION-YES",
-  "lastUpdateId": "76a23086a00670000000000000000000000000000000000000000000000000000000000000000000002",
-  "bids": [
-    ["0.614", "100.00"],
-    ["0.613", "25.50"]
-  ],
-  "asks": [
-    ["0.616", "50.00"],
-    ["0.617", "75.25"]
-  ]
-}
-```
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `lastUpdateId` | STRING | Opaque chain-order cursor. Lex-comparable: a larger string means a newer event has touched this `(marketAddress, symbol)`. Empty string when no order event has landed yet. Clients SHOULD compare for equality to detect "no change" and string-lex order to detect "moved forward"; they SHOULD NOT parse it as an integer. |
-
-Each bid or ask item is:
-
-```text
-[price, quantity]
-```
-
-### Recent Trades
-
-```http
-GET /api/v1/trades
-```
-
-Security: `NONE`
-
-Fetch the most recent public trades for one symbol in one market. A trade is a
-single maker↔taker match produced by the order book — the public, account-agnostic
-view of the fills that surface privately as `x: "TRADE"` frames on the
-[`orderUpdate`](#order-updates) WebSocket stream. No authentication is required and
-no owner information is returned; the endpoint exposes only price, size, direction,
-and time.
-
-This endpoint is unaffected by market lifecycle status: trades are returned for any
-market that has been reconciled at least once, including terminal phases
-(`RESOLVED`, `CANCELLED`, `EXPIRED`), so the trade tape remains readable after the
-book closes. It is eventually consistent — a just-matched trade may briefly lag the
-fill that produced it until the indexer projects the match.
-
-Query parameters:
-
-| Name | Type | Mandatory | Description |
-| --- | --- | --- | --- |
-| `marketAddress` | STRING | YES | Market address. Example: `0:market-address`. |
-| `symbol` | STRING | YES | Outcome-token symbol. Example: `PM-2026-ELECTION-YES`. |
-| `limit` | INT | NO | Number of trades to return, newest first. Default: `20`. Max: `1000`. |
-
-Response:
-
-```json
-[
-  {
-    "tradeId": "76a23086a00670000000000000000000000000000000000000000000000000000000000000000000005",
-    "price": "0.615",
-    "qty": "1.00",
-    "quoteQty": "0.615000",
-    "time": 1710000008980,
-    "isBuyerMaker": true
-  },
-  {
-    "tradeId": "76a23086a00670000000000000000000000000000000000000000000000000000000000000000000004",
-    "price": "0.615",
-    "qty": "0.50",
-    "quoteQty": "0.307500",
-    "time": 1710000004980,
-    "isBuyerMaker": true
-  }
-]
-```
-
-The response is a bare JSON array, newest trade first, ordered by the same
-server-internal chain-order key used by [`GET /api/v1/orders`](#orders) (descending).
-An empty array means no trade has matched on this symbol yet.
-
-Trade fields:
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `tradeId` | STRING | Opaque, lex-comparable id for one maker↔taker match. The identical value is carried by the WebSocket [`orderUpdate`](#order-updates) fill frame as field `t`, on both sides of the match — so a client can correlate a public trade with its own private fills and deduplicate across the two feeds. Treat it as an opaque token; do not parse it. |
-| `price` | DECIMAL | Match (clearing) price, scaled by the outcome price precision. |
-| `qty` | DECIMAL | Matched outcome-token quantity, scaled by the outcome quantity precision. |
-| `quoteQty` | DECIMAL | Quote-asset notional of the match (`price × qty`), scaled by the quote asset's on-chain `decimals`. |
-| `time` | LONG | On-chain match time in Unix milliseconds, truncated from the indexed microsecond timestamp — same convention as `time` / `updateTime` on [`GET /api/v1/orders`](#orders). |
-| `isBuyerMaker` | BOOLEAN | `true` when the resting (maker) side was the buy order and the taker was selling; `false` when the taker was buying. Determines display direction: `true` = taker sold (downtick), `false` = taker bought (uptick). Matches Binance `isBuyerMaker` semantics. |
-
-Each public trade is the account-agnostic view of a fill that also appears on the
-private [`orderUpdate`](#order-updates) stream (`x: "TRADE"`). The fields line up
-one-to-one, so a client subscribed to both feeds can match them by `tradeId` / `t`:
-
-| `/api/v1/trades` field | `orderUpdate` fill field | Note |
-| --- | --- | --- |
-| `tradeId` | `t` | Same opaque match id on both feeds, and on both sides of the match. |
-| `price` | `L` | Last fill price. |
-| `qty` | `l` | Last fill quantity. |
-| `time` | `T` | On-chain match / transaction time. |
-| `isBuyerMaker` | `S` + `m` | Public trade carries the side-agnostic direction; the `orderUpdate` frame carries the recipient's own side (`S`) and maker flag (`m`). |
-
-Errors:
-
-| Condition | Code | HTTP |
-| --- | --- | --- |
-| `marketAddress` or `symbol` missing or blank | `-1102` | 400 |
-| `limit` present but not an integer | `-1130` | 400 |
-| `limit` outside `[1, 1000]` | `-1102` | 400 |
-| `(marketAddress, symbol)` pair not found, or its market has not been reconciled yet | `-1121` | 404 |
-| Trade data is temporarily inconsistent | `-1500` | 503 |
 
 ## Account Endpoints
 
@@ -922,7 +922,7 @@ Query parameters:
 
 | Name | Type | Mandatory | Description |
 | --- | --- | --- | --- |
-| `marketAddress` | STRING | YES | Market address. Example: `0:market-address`. |
+| `predictionMarketAddress` | STRING | YES | Market address. Example: `0:market-address`. |
 
 Signed parameters:
 
@@ -936,7 +936,7 @@ Response:
 
 ```json
 {
-  "marketAddress": "0:market-address",
+  "predictionMarketAddress": "0:market-address",
   "updateTime": 1710000000000,
   "balances": [
     {
@@ -959,11 +959,11 @@ Response fields:
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `marketAddress` | STRING | Echoed from the request. |
+| `predictionMarketAddress` | STRING | Echoed from the request. |
 | `updateTime` | LONG | Server timestamp (Unix ms) captured when the request was served. |
-| `balances` | ARRAY | One entry per outcome of the market, sorted by `outcomeId` ascending. Length equals the market's `outcomes[]` length in `/api/v1/markets`. |
-| `balances[].outcomeId` | INT | Stable outcome id; matches `outcomes[].outcomeId` from `/api/v1/markets`. |
-| `balances[].symbol` | STRING | Outcome-token symbol; matches `outcomes[].symbol` from `/api/v1/markets`. |
+| `balances` | ARRAY | One entry per outcome of the market, sorted by `outcomeId` ascending. Length equals the market's `outcomes[]` length in `/api/v1/prediction/markets`. |
+| `balances[].outcomeId` | INT | Stable outcome id; matches `outcomes[].outcomeId` from `/api/v1/prediction/markets`. |
+| `balances[].symbol` | STRING | Outcome-token symbol; matches `outcomes[].symbol` from `/api/v1/prediction/markets`. |
 | `balances[].free` | DECIMAL | Outcome tokens currently held by the trading PrivateNote across clean, debt, and coupon stake pools, scaled by the quote asset's on-chain `decimals` (same scaling as `/api/v1/account`). |
 | `balances[].lockedInOrders` | DECIMAL | Outcome tokens locked in resting SELL orders on this outcome, scaled by the quote asset's on-chain `decimals`. |
 
@@ -971,17 +971,17 @@ Errors:
 
 | Condition | Code | HTTP |
 | --- | --- | --- |
-| `marketAddress` missing or blank | `-1102` | 400 |
-| `marketAddress` not found, or its market has not been reconciled yet | `-1121` | 404 |
+| `predictionMarketAddress` missing or blank | `-1102` | 400 |
+| `predictionMarketAddress` not found, or its market has not been reconciled yet | `-1121` | 404 |
 | Authenticated account has no PrivateNote contract deployed at its resolved address | `-2013` | 404 |
 | Backend could not read the trading PrivateNote state (gateway timeout, malformed reply, unknown token type, decimals out of range) | `-1500` | 503 |
 
-## Position Endpoints
+## Prediction Position Endpoints
 
 ### Buy Full Set
 
 ```http
-POST /api/v1/buyFullSet
+POST /api/v1/prediction/buyFullSet
 ```
 
 Security: `TRADE`
@@ -996,7 +996,7 @@ Body parameters:
 
 | Name | Type | Mandatory | Description |
 | --- | --- | --- | --- |
-| `marketAddress` | STRING | YES | Market address. Example: `0:market-address`. |
+| `predictionMarketAddress` | STRING | YES | Market address. Example: `0:market-address`. |
 | `collateral` | DECIMAL | YES | Amount of the market's `quoteAsset` to allocate. Scaled by the quote-asset on-chain `decimals`. |
 
 Signed query parameters:
@@ -1011,7 +1011,7 @@ Response:
 
 ```json
 {
-  "marketAddress": "0:market-address",
+  "predictionMarketAddress": "0:market-address",
   "transactTime": 1710000000000
 }
 ```
@@ -1020,7 +1020,7 @@ Response fields:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `marketAddress` | STRING | Echoed from the request. |
+| `predictionMarketAddress` | STRING | Echoed from the request. |
 | `transactTime` | LONG | Server timestamp (Unix ms) when the operation was accepted. |
 
 The response confirms acceptance only. The resulting collateral debit and outcome-token credits become visible through [`GET /api/v1/account`](#account-balance) and [`GET /api/v1/account/balances`](#market-outcome-balances) once the chain confirms.
@@ -1029,9 +1029,9 @@ Errors:
 
 | Condition | Code | HTTP |
 | --- | --- | --- |
-| `marketAddress` or `collateral` missing | `-1102` | 400 |
+| `predictionMarketAddress` or `collateral` missing | `-1102` | 400 |
 | `collateral` not positive, exceeds quote-asset precision, or other body shape violation | `-1130` | 400 |
-| `marketAddress` not found, or its market has not been reconciled yet | `-1121` | 404 |
+| `predictionMarketAddress` not found, or its market has not been reconciled yet | `-1121` | 404 |
 | Market status is not `AWAITING_FREEZE` or `TRADING`; free quote-asset balance is below `collateral`; the chain rejected the request | `-2010` | 400 |
 | Authenticated account has no PrivateNote contract deployed at its resolved address | `-2013` | 404 |
 | Trading note is busy with another operation; retry shortly | `-2014` | 429 |
@@ -1040,7 +1040,7 @@ Errors:
 ### Sell Full Set
 
 ```http
-POST /api/v1/sellFullSet
+POST /api/v1/prediction/sellFullSet
 ```
 
 Security: `TRADE`
@@ -1053,8 +1053,8 @@ Body parameters:
 
 | Name | Type | Mandatory | Description |
 | --- | --- | --- | --- |
-| `marketAddress` | STRING | YES | Market address. Example: `0:market-address`. |
-| `amounts` | ARRAY of DECIMAL | YES | Per-outcome amounts to sell back. Length MUST equal the market's `outcomes[]` length in `/api/v1/markets`. Element `i` corresponds to `outcomes[i].outcomeId` and is scaled by `outcomes[i].quantityPrecision`. Elements MAY be zero; at least one element MUST be non-zero. |
+| `predictionMarketAddress` | STRING | YES | Market address. Example: `0:market-address`. |
+| `amounts` | ARRAY of DECIMAL | YES | Per-outcome amounts to sell back. Length MUST equal the market's `outcomes[]` length in `/api/v1/prediction/markets`. Element `i` corresponds to `outcomes[i].outcomeId` and is scaled by `outcomes[i].quantityPrecision`. Elements MAY be zero; at least one element MUST be non-zero. |
 
 Signed query parameters:
 
@@ -1068,7 +1068,7 @@ Response:
 
 ```json
 {
-  "marketAddress": "0:market-address",
+  "predictionMarketAddress": "0:market-address",
   "transactTime": 1710000000000
 }
 ```
@@ -1077,7 +1077,7 @@ Response fields:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `marketAddress` | STRING | Echoed from the request. |
+| `predictionMarketAddress` | STRING | Echoed from the request. |
 | `transactTime` | LONG | Server timestamp (Unix ms) when the operation was accepted. |
 
 The response confirms acceptance only. The credited collateral and the burned outcome-token amounts become visible through [`GET /api/v1/account`](#account-balance) and [`GET /api/v1/account/balances`](#market-outcome-balances) once the chain confirms.
@@ -1086,9 +1086,9 @@ Errors:
 
 | Condition | Code | HTTP |
 | --- | --- | --- |
-| `marketAddress` or `amounts` missing | `-1102` | 400 |
+| `predictionMarketAddress` or `amounts` missing | `-1102` | 400 |
 | `amounts` length does not equal the market's outcome count, any element negative or beyond precision, all elements zero | `-1130` | 400 |
-| `marketAddress` not found, or its market has not been reconciled yet | `-1121` | 404 |
+| `predictionMarketAddress` not found, or its market has not been reconciled yet | `-1121` | 404 |
 | Market status is not `TRADING` or `RESOLVING`; caller does not hold enough of some outcome to cover the requested amount; the chain rejected the request | `-2010` | 400 |
 | Authenticated account has no PrivateNote contract deployed at its resolved address | `-2013` | 404 |
 | Trading note is busy with another operation; retry shortly | `-2014` | 429 |
@@ -1097,7 +1097,7 @@ Errors:
 ### Claim
 
 ```http
-POST /api/v1/claim
+POST /api/v1/prediction/claim
 ```
 
 Security: `TRADE`
@@ -1108,7 +1108,7 @@ Body parameters:
 
 | Name | Type | Mandatory | Description |
 | --- | --- | --- | --- |
-| `marketAddress` | STRING | YES | Market address. Example: `0:market-address`. |
+| `predictionMarketAddress` | STRING | YES | Market address. Example: `0:market-address`. |
 
 Signed query parameters:
 
@@ -1122,7 +1122,7 @@ Response:
 
 ```json
 {
-  "marketAddress": "0:market-address",
+  "predictionMarketAddress": "0:market-address",
   "transactTime": 1710000000000
 }
 ```
@@ -1131,7 +1131,7 @@ Response fields:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `marketAddress` | STRING | Echoed from the request. |
+| `predictionMarketAddress` | STRING | Echoed from the request. |
 | `transactTime` | LONG | Server timestamp (Unix ms) when the operation was accepted. |
 
 The response confirms acceptance only. The credited collateral becomes visible through [`GET /api/v1/account`](#account-balance) once the chain confirms.
@@ -1140,19 +1140,19 @@ Errors:
 
 | Condition | Code | HTTP |
 | --- | --- | --- |
-| `marketAddress` missing | `-1102` | 400 |
-| `marketAddress` not found, or its market has not been reconciled yet | `-1121` | 404 |
+| `predictionMarketAddress` missing | `-1102` | 400 |
+| `predictionMarketAddress` not found, or its market has not been reconciled yet | `-1121` | 404 |
 | Market status is not `RESOLVED` or `CANCELLED` | `-2010` | 400 |
 | Authenticated account has no PrivateNote contract deployed at its resolved address | `-2013` | 404 |
 | Trading note is busy with another operation; retry shortly | `-2014` | 429 |
 | Backend could not submit the transaction (gateway timeout, malformed reply) | `-1500` | 503 |
 
-## Trading Endpoints
+## Prediction Trading Endpoints
 
 ### New Order
 
 ```http
-POST /api/v1/order
+POST /api/v1/prediction/order
 ```
 
 Security: `TRADE`
@@ -1163,11 +1163,11 @@ Body parameters:
 
 | Name | Type | Mandatory | Description |
 | --- | --- | --- | --- |
-| `marketAddress` | STRING | YES | Market address. Example: `0:market-address`. |
+| `predictionMarketAddress` | STRING | YES | Market address. Example: `0:market-address`. |
 | `symbol` | STRING | YES | Outcome-token symbol. Example: `PM-2026-ELECTION-YES`. |
 | `newOrderClientId` | STRING | NO | Optional client-defined order identifier. If omitted, the API generates a random value and returns it as `clientOrderId` in the response. |
 | `side` | ENUM | YES | Order side. See [Order Side](#order-side). |
-| `quantity` | DECIMAL | YES | Outcome-token quantity. Must follow `stepSize`. For `MARKET` buy orders this field represents the amount of the market `quoteAsset` to spend, for example `USDC`. In that case, `quantityPrecision` and `stepSize` from `/api/v1/markets` apply to the quote-asset spend amount exactly as sent in the request. |
+| `quantity` | DECIMAL | YES | Outcome-token quantity. Must follow `stepSize`. For `MARKET` buy orders this field represents the amount of the market `quoteAsset` to spend, for example `USDC`. In that case, `quantityPrecision` and `stepSize` from `/api/v1/prediction/markets` apply to the quote-asset spend amount exactly as sent in the request. |
 | `price` | DECIMAL | NO | Required for `LIMIT` orders. Must follow `tickSize`. |
 | `type` | ENUM | NO | Order type. See [Order Type](#order-type). Default: `LIMIT`. |
 | `timeInForce` | ENUM | NO | For `LIMIT` orders only. See [Time In Force](#time-in-force). Default: `GTC`. |
@@ -1194,16 +1194,16 @@ Response fields:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `clientOrderId` | STRING | Either the `newOrderClientId` sent in the request, or a server-generated identifier when none was provided. Use it to look up the order in `/api/v1/orders` until the server-assigned `orderId` is available. |
+| `clientOrderId` | STRING | Either the `newOrderClientId` sent in the request, or a server-generated identifier when none was provided. Use it to look up the order in `/api/v1/prediction/orders` until the server-assigned `orderId` is available. |
 | `transactTime` | LONG | Server timestamp (Unix ms) when the order was accepted. |
 | `status` | ENUM | Always [`PENDING_NEW`](#order-status) on success. |
 
-The response confirms acceptance only. The full order state — `orderId`, fills, accepted price — becomes available through [`GET /api/v1/orders`](#orders) shortly after; look up by `clientOrderId`.
+The response confirms acceptance only. The full order state — `orderId`, fills, accepted price — becomes available through [`GET /api/v1/prediction/orders`](#orders) shortly after; look up by `clientOrderId`.
 
 ### Cancel Order
 
 ```http
-DELETE /api/v1/order
+DELETE /api/v1/prediction/order
 ```
 
 Security: `TRADE`
@@ -1214,7 +1214,7 @@ Parameters:
 
 | Name | Type | Mandatory | Description |
 | --- | --- | --- | --- |
-| `marketAddress` | STRING | YES | Market address. Example: `0:market-address`. |
+| `predictionMarketAddress` | STRING | YES | Market address. Example: `0:market-address`. |
 | `symbol` | STRING | YES | Outcome-token symbol. Example: `PM-2026-ELECTION-YES`. |
 | `orderId` | STRING | YES | Order ID to cancel. |
 | `timestamp` | LONG | YES | Unix timestamp in milliseconds. |
@@ -1241,25 +1241,25 @@ Response fields:
 | `transactTime` | LONG | Server timestamp (Unix ms) when the cancel request was accepted. |
 | `status` | ENUM | Always [`PENDING_CANCEL`](#order-status) on success. |
 
-The response confirms acceptance only. The final outcome — `CANCELED`, or `FILLED` if matching raced the cancel — becomes visible through [`GET /api/v1/orders`](#orders) shortly after.
+The response confirms acceptance only. The final outcome — `CANCELED`, or `FILLED` if matching raced the cancel — becomes visible through [`GET /api/v1/prediction/orders`](#orders) shortly after.
 
 ### New Batch Orders
 
 ```http
-POST /api/v1/batchOrders
+POST /api/v1/prediction/batchOrders
 ```
 
 Security: `TRADE`
 
-Create multiple orders in one request. All orders in the batch are submitted to the single market symbol identified by the top-level `marketAddress` and `symbol`.
+Create multiple orders in one request. All orders in the batch are submitted to the single market symbol identified by the top-level `predictionMarketAddress` and `symbol`.
 
 Body parameters:
 
 | Name | Type | Mandatory | Description |
 | --- | --- | --- | --- |
-| `marketAddress` | STRING | YES | Market address. Example: `0:market-address`. |
+| `predictionMarketAddress` | STRING | YES | Market address. Example: `0:market-address`. |
 | `symbol` | STRING | YES | Outcome-token symbol. Example: `PM-2026-ELECTION-YES`. |
-| `orders` | ARRAY | YES | List of orders to create on the specified market symbol. Must contain at least one item; the maximum is the outcome's `maxBatchSize` from `/api/v1/markets`. The backend rejects an empty array before submission with `-1130 / 400`. |
+| `orders` | ARRAY | YES | List of orders to create on the specified market symbol. Must contain at least one item; the maximum is the outcome's `maxBatchSize` from `/api/v1/prediction/markets`. The backend rejects an empty array before submission with `-1130 / 400`. |
 
 Each order item:
 
@@ -1267,7 +1267,7 @@ Each order item:
 | --- | --- | --- | --- |
 | `newOrderClientId` | STRING | NO | Optional client-defined order identifier. If omitted, the API generates a random value and returns it as `clientOrderId` in the response. Each item is generated or accepted independently; intra-batch duplicates are detected by the exchange during placement and surface as `-1130 / 400`. |
 | `side` | ENUM | YES | Order side. See [Order Side](#order-side). |
-| `quantity` | DECIMAL | YES | Outcome-token quantity. Must follow `stepSize`. For `MARKET` buy orders this field represents the amount of the market `quoteAsset` to spend, for example `USDC`. In that case, `quantityPrecision` and `stepSize` from `/api/v1/markets` apply to the quote-asset spend amount exactly as sent in the request. |
+| `quantity` | DECIMAL | YES | Outcome-token quantity. Must follow `stepSize`. For `MARKET` buy orders this field represents the amount of the market `quoteAsset` to spend, for example `USDC`. In that case, `quantityPrecision` and `stepSize` from `/api/v1/prediction/markets` apply to the quote-asset spend amount exactly as sent in the request. |
 | `price` | DECIMAL | NO | Required for `LIMIT` orders. Must follow `tickSize`. |
 | `type` | ENUM | NO | Order type. See [Order Type](#order-type). Default: `LIMIT`. |
 | `timeInForce` | ENUM | NO | For `LIMIT` orders only. See [Time In Force](#time-in-force). Default: `GTC`. |
@@ -1284,7 +1284,7 @@ Request body:
 
 ```json
 {
-  "marketAddress": "0:market-address",
+  "predictionMarketAddress": "0:market-address",
   "symbol": "PM-2026-ELECTION-YES",
   "orders": [
     {
@@ -1328,11 +1328,11 @@ Response items, in request order:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `clientOrderId` | STRING | Either the `newOrderClientId` sent in the corresponding request item, or a server-generated identifier when none was provided. Use it to look up the order in `/api/v1/openOrders` until the server-assigned `orderId` is available. |
+| `clientOrderId` | STRING | Either the `newOrderClientId` sent in the corresponding request item, or a server-generated identifier when none was provided. Use it to look up the order in `/api/v1/prediction/openOrders` until the server-assigned `orderId` is available. |
 | `transactTime` | LONG | Server timestamp (Unix ms) when the batch was accepted. The same value is repeated for every item in the response. |
 | `status` | ENUM | Always [`PENDING_NEW`](#order-status) on success. |
 
-The response confirms acceptance only. For each item, the full order state — `orderId`, fills, accepted price — becomes available through [`GET /api/v1/openOrders`](#current-open-orders) shortly after; look up by `clientOrderId`.
+The response confirms acceptance only. For each item, the full order state — `orderId`, fills, accepted price — becomes available through [`GET /api/v1/prediction/openOrders`](#current-open-orders) shortly after; look up by `clientOrderId`.
 
 Response shape depends on outcome: on success the body is a JSON array with one object per accepted item, in request order; on failure the body is a single standard error envelope (`{ "code": ..., "msg": ... }`), never an array.
 
@@ -1341,7 +1341,7 @@ Batch creation is atomic: if any order in the batch fails validation, the whole 
 ### Cancel Batch Orders
 
 ```http
-DELETE /api/v1/batchOrders
+DELETE /api/v1/prediction/batchOrders
 ```
 
 Security: `TRADE`
@@ -1352,9 +1352,9 @@ Body parameters:
 
 | Name | Type | Mandatory | Description |
 | --- | --- | --- | --- |
-| `marketAddress` | STRING | YES | Market address. Example: `0:market-address`. |
+| `predictionMarketAddress` | STRING | YES | Market address. Example: `0:market-address`. |
 | `symbol` | STRING | YES | Outcome-token symbol. Example: `PM-2026-ELECTION-YES`. |
-| `orderIds` | ARRAY | YES | List of order IDs to cancel on the specified market symbol. Must contain at least one item; the maximum is the outcome's `maxBatchSize` from `/api/v1/markets`. The backend rejects an empty array before submission with `-1130 / 400`. Duplicate `orderId` values within the array are rejected with `-1130 / 400` — each id consumes one slot in the chain's batch window, and a duplicate receipt carries no extra signal. |
+| `orderIds` | ARRAY | YES | List of order IDs to cancel on the specified market symbol. Must contain at least one item; the maximum is the outcome's `maxBatchSize` from `/api/v1/prediction/markets`. The backend rejects an empty array before submission with `-1130 / 400`. Duplicate `orderId` values within the array are rejected with `-1130 / 400` — each id consumes one slot in the chain's batch window, and a duplicate receipt carries no extra signal. |
 
 Signed query parameters:
 
@@ -1368,7 +1368,7 @@ Request body:
 
 ```json
 {
-  "marketAddress": "0:market-address",
+  "predictionMarketAddress": "0:market-address",
   "symbol": "PM-2026-ELECTION-YES",
   "orderIds": ["123456789", "123456790"]
 }
@@ -1402,12 +1402,12 @@ Response fields (one element per requested `orderId`, in request order):
 | `transactTime` | LONG | Server timestamp (Unix ms) when the cancel batch was accepted. Identical across every item — one chain submission, one moment of acceptance. |
 | `status` | ENUM | Always [`PENDING_CANCEL`](#order-status) on success. |
 
-The response confirms acceptance only. The final outcome per id — `CANCELED`, or `FILLED` if matching raced the cancel — becomes visible through [`GET /api/v1/orders`](#orders) shortly after.
+The response confirms acceptance only. The final outcome per id — `CANCELED`, or `FILLED` if matching raced the cancel — becomes visible through [`GET /api/v1/prediction/orders`](#orders) shortly after.
 
 ### Cancel All Open Orders On Symbol
 
 ```http
-DELETE /api/v1/openOrders
+DELETE /api/v1/prediction/openOrders
 ```
 
 Security: `TRADE`
@@ -1418,7 +1418,7 @@ Parameters:
 
 | Name | Type | Mandatory | Description |
 | --- | --- | --- | --- |
-| `marketAddress` | STRING | YES | Market address. Example: `0:market-address`. |
+| `predictionMarketAddress` | STRING | YES | Market address. Example: `0:market-address`. |
 | `symbol` | STRING | YES | Outcome-token symbol. Example: `PM-2026-ELECTION-YES`. |
 | `timestamp` | LONG | YES | Unix timestamp in milliseconds. |
 | `recvWindow` | LONG | NO | Request validity window in milliseconds. |
@@ -1429,7 +1429,7 @@ Response:
 ```json
 [
   {
-    "marketAddress": "0:market-address",
+    "predictionMarketAddress": "0:market-address",
     "symbol": "PM-2026-ELECTION-YES",
     "orderId": "123456789",
     "price": "0.615",
@@ -1448,7 +1448,7 @@ Response:
 ### Orders
 
 ```http
-GET /api/v1/orders
+GET /api/v1/prediction/orders
 ```
 
 Security: `USER_DATA`
@@ -1459,8 +1459,8 @@ Parameters:
 
 | Name | Type | Mandatory | Description |
 | --- | --- | --- | --- |
-| `marketAddress` | STRING | NO | Market address. Together with `symbol`, selects one market symbol. If both are omitted, returns orders across all markets. |
-| `symbol` | STRING | NO | Outcome-token symbol. Together with `marketAddress`, selects one market symbol. If one is sent without the other, the request is invalid. |
+| `predictionMarketAddress` | STRING | NO | Market address. Together with `symbol`, selects one market symbol. If both are omitted, returns orders across all markets. |
+| `symbol` | STRING | NO | Outcome-token symbol. Together with `predictionMarketAddress`, selects one market symbol. If one is sent without the other, the request is invalid. |
 | `status` | STRING | NO | Comma-separated list of [Order Status](#order-status) values to include. Allowed: `NEW`, `PARTIALLY_FILLED`, `FILLED`, `CANCELED`, `REJECTED`. Tokens are trimmed and de-duplicated. Default: include all statuses. |
 | `limit` | INT | NO | Page size. Default: `100`. Range: `[1, 500]`. |
 | `cursor` | STRING | NO | Opaque lex-comparable string returned by the server as `nextCursor`. Pass back verbatim to fetch the next page. An empty or whitespace-only cursor returns `-1102 / 400`. A well-formed cursor that lies past the last order returns an empty page with `nextCursor: null` — not an error. Omit for the first page. |
@@ -1470,14 +1470,14 @@ Parameters:
 
 Behavior:
 
-- If both `marketAddress` and `symbol` are omitted, returns orders for the authenticated account across all markets.
-- If both `marketAddress` and `symbol` are sent, returns orders for that one market symbol.
-- If only one of `marketAddress` / `symbol` is sent, returns `-1102` with HTTP `400`.
+- If both `predictionMarketAddress` and `symbol` are omitted, returns orders for the authenticated account across all markets.
+- If both `predictionMarketAddress` and `symbol` are sent, returns orders for that one market symbol.
+- If only one of `predictionMarketAddress` / `symbol` is sent, returns `-1102` with HTTP `400`.
 - If `limit` is outside `[1, 500]`, returns `-1102` with HTTP `400`.
 - If `limit` is present but not an integer, returns `-1130` with HTTP `400`.
 - If `cursor` is empty or whitespace-only, returns `-1102` with HTTP `400`. A well-formed cursor that points past the current set of orders is not an error — the response is `{ "orders": [], "nextCursor": null }`.
 - If `status` contains an unknown token, returns `-1130` with HTTP `400`.
-- If the `(marketAddress, symbol)` pair does not exist, returns `-1121` with HTTP `404`.
+- If the `(predictionMarketAddress, symbol)` pair does not exist, returns `-1121` with HTTP `404`.
 - Empty results are returned as `{ "orders": [], "nextCursor": null }`. A page may also return `orders: []` together with a non-null `nextCursor`; clients should keep paging until `nextCursor` is `null`.
 - Results are sorted by a single server-internal chain-order key, **descending** (most recently placed first). For all-market requests this ordering is global across all returned orders.
 - Pagination is cursor-based on the same chain-order key. The key is set once when the order is placed and never moves for the life of the order — subsequent fills, cancels, and status transitions do not touch it — so concurrent activity between page reads cannot duplicate or skip rows.
@@ -1489,7 +1489,7 @@ Response:
 {
   "orders": [
     {
-      "marketAddress": "0:market-address",
+      "predictionMarketAddress": "0:market-address",
       "symbol": "PM-2026-ELECTION-YES",
       "orderId": "123456789",
       "clientOrderId": "mm-order-0001",
@@ -1521,7 +1521,7 @@ Order fields:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `marketAddress` | STRING | Market address. |
+| `predictionMarketAddress` | STRING | Market address. |
 | `symbol` | STRING | Outcome-token symbol. |
 | `orderId` | STRING | Chain-side order id. Empty string for `REJECTED` orders (the chain never assigns an id to a rejected placement). |
 | `clientOrderId` | STRING | Client-supplied id, or an empty string if absent. |
@@ -1566,24 +1566,24 @@ Order fields:
 
 | Value | Description |
 | --- | --- |
-| `PENDING_NEW` | Order accepted by the exchange and not yet on the book. Will transition to `NEW` (or `PARTIALLY_FILLED` if it immediately matches) once visible in `/api/v1/orders`. |
+| `PENDING_NEW` | Order accepted by the exchange and not yet on the book. Will transition to `NEW` (or `PARTIALLY_FILLED` if it immediately matches) once visible in `/api/v1/prediction/orders`. |
 | `NEW` | Order is open and has no fills. |
 | `PARTIALLY_FILLED` | Order is open and partially filled. |
-| `PENDING_CANCEL` | Cancel request accepted by the exchange but not yet applied to the book. Will transition to `CANCELED` (or `FILLED` if matching raced the cancel) once the order's stored status flips in `/api/v1/orders`. |
+| `PENDING_CANCEL` | Cancel request accepted by the exchange but not yet applied to the book. Will transition to `CANCELED` (or `FILLED` if matching raced the cancel) once the order's stored status flips in `/api/v1/prediction/orders`. |
 | `FILLED` | Order is completely filled. |
 | `CANCELED` | Order was canceled by the user or system. |
 | `REJECTED` | Order was rejected and was not opened. |
 
-## WebSocket Streams
+## Prediction WebSocket Streams
 
 ### Connection
 
-Real-time stream of order lifecycle updates for the authenticated account. Delta-only — no snapshot is sent on subscribe. Clients reconcile current state via [`GET /api/v1/orders`](#orders) after (re)connect.
+Real-time stream of order lifecycle updates for the authenticated account. Delta-only — no snapshot is sent on subscribe. Clients reconcile current state via [`GET /api/v1/prediction/orders`](#orders) after (re)connect.
 
 Base URL:
 
 ```text
-wss://api.dex.do.example.com/ws/v1/user
+wss://api.dex.do.example.com/ws/v1/prediction/user
 ```
 
 Security: `USER_DATA`. Subscription requires the same signed envelope as private REST endpoints — `X-DODEX-APIKEY`, `timestamp`, `signature`, optional `recvWindow` — see [Signature Formation](#signature-formation). The signature payload is the canonical query string of the subscription parameters (sorted by key, excluding `signature`), HMAC-SHA256 with the API secret.
@@ -1617,14 +1617,14 @@ Connection lifecycle:
 
 Every `orderUpdate` carries a per-account contiguous integer `sq`. For one subscription, `sq` of the next event is **exactly** `prev_sq + 1`. The first event a fresh account ever receives carries `sq = 1`. `sq` is scoped to the authenticated account — one client never observes another account's counter.
 
-[`GET /api/v1/orders`](#orders) returns `lastSq` — the largest `sq` the server has already emitted for the caller's account at the moment the snapshot was assembled. Together with `sq` on each event, this lets clients splice a REST snapshot into the live stream and detect lost events without any server-side replay buffer.
+[`GET /api/v1/prediction/orders`](#orders) returns `lastSq` — the largest `sq` the server has already emitted for the caller's account at the moment the snapshot was assembled. Together with `sq` on each event, this lets clients splice a REST snapshot into the live stream and detect lost events without any server-side replay buffer.
 
 Recommended client algorithm:
 
 ```text
 on (re)connect:
   open WebSocket, subscribe, start buffering incoming events
-  fetch GET /api/v1/orders → L = lastSq
+  fetch GET /api/v1/prediction/orders → L = lastSq
   expected_next = L + 1
   discard buffered events with sq <= L
   apply remaining buffered events in sq-asc order:
@@ -1636,7 +1636,7 @@ on every live event:
 
 The algorithm above applies to `orderUpdate` frames only. Control frames (`ping`, `pong`) carry no `sq` and do not advance `expected_next` — clients dispatch them on `e` / `method` before running the gap check.
 
-`sq` is monotonic over the life of the account, not the life of the subscription — a reconnect does not reset the counter. The snapshot watermark `lastSq` from `GET /api/v1/orders` is therefore directly comparable with any `sq` the client has previously stored.
+`sq` is monotonic over the life of the account, not the life of the subscription — a reconnect does not reset the counter. The snapshot watermark `lastSq` from `GET /api/v1/prediction/orders` is therefore directly comparable with any `sq` the client has previously stored.
 
 ### Order Updates
 
@@ -1761,9 +1761,9 @@ Field reference:
 | `l` | DECIMAL | Last fill quantity. `"0"` on non-trade events. |
 | `L` | DECIMAL | Last fill price. `"0"` on non-trade events. |
 | `z` | DECIMAL | Cumulative filled quantity over the life of the order. |
-| `n` | DECIMAL | Commission for the last fill, as a signed decimal string. Negative values are rebates **credited** to the account (see `makerComission` on [`/api/v1/markets`](#markets)). `"0"` on non-trade events. |
+| `n` | DECIMAL | Commission for the last fill, as a signed decimal string. Negative values are rebates **credited** to the account (see `makerComission` on [`/api/v1/prediction/markets`](#prediction-markets)). `"0"` on non-trade events. |
 | `N` | STRING \| null | Commission asset symbol. `null` on non-trade events. |
-| `t` | STRING \| null | Trade id for the last fill. Identical to `tradeId` in [`GET /api/v1/trades`](#recent-trades) for the same match, so the private fill can be correlated with the public trade tape. `null` on non-trade events. |
+| `t` | STRING \| null | Trade id for the last fill. Identical to `tradeId` in [`GET /api/v1/prediction/trades`](#prediction-trades) for the same match, so the private fill can be correlated with the public trade tape. `null` on non-trade events. |
 | `m` | BOOLEAN \| null | `true` if this fill was on the maker side, `false` for taker, `null` on non-trade events. |
 | `O` | LONG | Order creation time, Unix ms. Stable across all events for the same order. |
 | `T` | LONG | Transaction time — when this specific event was produced on-chain, Unix ms. |
@@ -1784,7 +1784,7 @@ Field reference:
 | `REJECTED` | Order was rejected and never opened. `X` transitions to `REJECTED`; `i` is empty. |
 | `EXPIRED` | Order ran out under its `timeInForce` (e.g. `IOC` / `FOK` could not fill). `X` transitions to `CANCELED`. |
 
-`X` reuses [Order Status](#order-status) — the same enum returned by `GET /api/v1/orders`.
+`X` reuses [Order Status](#order-status) — the same enum returned by `GET /api/v1/prediction/orders`.
 
 ## Validation Rules
 
@@ -1792,14 +1792,14 @@ Order creation MUST validate:
 
 | Rule | Source |
 | --- | --- |
-| `marketAddress` exists | `/api/v1/markets` |
-| `symbol` exists within the selected market | `/api/v1/markets` |
-| The selected market has `status == "TRADING"` (any other phase rejects order placement) | `/api/v1/markets` |
-| For `LIMIT` orders, `price` decimal places do not exceed `pricePrecision` | `/api/v1/markets` |
-| For `LIMIT` orders, `price` is a multiple of `tickSize` | `/api/v1/markets` |
-| `quantity` decimal places do not exceed `quantityPrecision` | `/api/v1/markets` |
-| `quantity` is a multiple of `stepSize` | `/api/v1/markets` |
-| For `LIMIT` orders, `price * quantity` is at least `minNotional` | `/api/v1/markets` |
-| For `MARKET` buy orders, `quantity` in the market `quoteAsset` is at least `minNotional` | `/api/v1/markets` |
-| For `MARKET` buy orders, `quantityPrecision` and `stepSize` apply to the quote-asset spend amount, not to outcome-token units | `/api/v1/markets` |
+| `predictionMarketAddress` exists | `/api/v1/prediction/markets` |
+| `symbol` exists within the selected market | `/api/v1/prediction/markets` |
+| The selected market has `status == "TRADING"` (any other phase rejects order placement) | `/api/v1/prediction/markets` |
+| For `LIMIT` orders, `price` decimal places do not exceed `pricePrecision` | `/api/v1/prediction/markets` |
+| For `LIMIT` orders, `price` is a multiple of `tickSize` | `/api/v1/prediction/markets` |
+| `quantity` decimal places do not exceed `quantityPrecision` | `/api/v1/prediction/markets` |
+| `quantity` is a multiple of `stepSize` | `/api/v1/prediction/markets` |
+| For `LIMIT` orders, `price * quantity` is at least `minNotional` | `/api/v1/prediction/markets` |
+| For `MARKET` buy orders, `quantity` in the market `quoteAsset` is at least `minNotional` | `/api/v1/prediction/markets` |
+| For `MARKET` buy orders, `quantityPrecision` and `stepSize` apply to the quote-asset spend amount, not to outcome-token units | `/api/v1/prediction/markets` |
 | Account has enough available balance (collateral for buys, outcome tokens for sells) | `/api/v1/account`, `/api/v1/account/balances` |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -313,7 +313,7 @@ rebuild. Rebuild (`--build`) only when the Rust source changes.
 curl -s http://localhost:8080/readiness
 
 # a real read path — exercises Postgres
-curl -s 'http://localhost:8080/api/v1/markets?limit=5' | jq
+curl -s 'http://localhost:8080/api/v1/prediction/markets?limit=5' | jq
 
 # indexer is making progress (look for the resumed-from-cursor line and
 # steadily advancing event ingestion)

--- a/docs/migrations/orders-cancel-remainder-cutover.md
+++ b/docs/migrations/orders-cancel-remainder-cutover.md
@@ -21,7 +21,7 @@ it today:
 
 Either condition means historical `live_orders` rows may not match the
 shape the current projector emits. Clear and reproject the full order
-lifecycle before exposing `/api/v1/orders`:
+lifecycle before exposing `/api/v1/prediction/orders`:
 
 1. Set `raw_events.processed_at = NULL` for affected `OrderBook.OrderPlaced`,
    `OrderBook.OrderFilled`, and `OrderBook.OrderCancelled` rows.

--- a/docs/tech-specs/data-schema.md
+++ b/docs/tech-specs/data-schema.md
@@ -83,7 +83,7 @@ Resume-points per ingestion stream. The indexer's main fetch loop persists the c
 
 ## Read-model — discovery
 
-The discovery side of the indexer tracks oracles, their event lists, and the events those lists carry. These tables feed the `event.*` block in `/api/v1/markets` responses.
+The discovery side of the indexer tracks oracles, their event lists, and the events those lists carry. These tables feed the `event.*` block in `/api/v1/prediction/markets` responses.
 
 ### `oracles`
 
@@ -160,14 +160,14 @@ One row per PMP (Prediction Market Pool) contract observed on chain. Discovered 
 | Column | Type | Notes |
 | --- | --- | --- |
 | `id` | `bigserial` PK | Internal FK target. |
-| `pmp_address` | `text` UNIQUE | The PMP contract address. Exposed as `marketAddress`. |
+| `pmp_address` | `text` UNIQUE | The PMP contract address. Exposed as `predictionMarketAddress`. |
 | `market_id` | `text` | Market identifier from `getDetails()`. NULL pre-reconcile. |
 | `name` | `text` | Market display name from `getDetails()`. Surfaces as `marketName`. |
 | `token_type` | `integer` FK → `ref_tokens(token_type)` | Quote-asset token type. |
 | `token_code` | `text` | Quote-asset code (denormalised from `ref_tokens` for read speed). |
 | `event_id` | `numeric(78,0)` | Oracle event id this market resolves against. |
 | `oracle_list_hash` | `numeric(78,0)` | EventList hash used in OrderBook derivation. NULL pre-reconcile. |
-| `orderbook_address` | `text` | The deterministic OrderBook address returned by `PMP.getOrderBookAddress()`. Written by the market reconciler on the first successful pass, including pre-`PoolsFrozen` rows. Nullable only during the pre-reconcile window; the CHECK predicate `last_reconciled_at IS NULL OR orderbook_address IS NOT NULL` enforces that every market visible to the API has a non-null `orderBookAddress`. A partial UNIQUE index on `orderbook_address WHERE orderbook_address IS NOT NULL` pins the contract-side per-market invariant — `/api/v1/orders` joins `live_orders` to `markets` on this column and relies on the at-most-one-row guarantee. |
+| `orderbook_address` | `text` | The deterministic OrderBook address returned by `PMP.getOrderBookAddress()`. Written by the market reconciler on the first successful pass, including pre-`PoolsFrozen` rows. Nullable only during the pre-reconcile window; the CHECK predicate `last_reconciled_at IS NULL OR orderbook_address IS NOT NULL` enforces that every market visible to the API has a non-null `predictionOrderBookAddress`. A partial UNIQUE index on `orderbook_address WHERE orderbook_address IS NOT NULL` pins the contract-side per-market invariant — `/api/v1/prediction/orders` joins `live_orders` to `markets` on this column and relies on the at-most-one-row guarantee. |
 | `approved` | `boolean` default `false` | Approval flag from `getDetails()`; flipped to `true` by the `TimingsSet` event. |
 | `is_cancelled` | `boolean` default `false` | On-chain cancellation flag from `getDetails()`. Either this or `cancelled_at` being set is enough to flip the derived status to `CANCELLED`. |
 | `stake_start` / `stake_end` / `result_start` / `result_end` | `bigint` (nullable) | Lifecycle timings (unix seconds). Written only by the `TimingsSet` event; reconciler does **not** touch these (H2 fix). NULL on all four = PENDING. |
@@ -192,7 +192,7 @@ Indices:
 | `markets_status_idx` (`approved, is_cancelled`) | Coarse status filters. |
 | `markets_pending_reconcile_idx` (partial: `last_reconciled_at IS NULL`) | Drives the market reconciler's pending-row SELECT. |
 | `markets_terminal_idx` (partial: `resolved_at IS NOT NULL OR cancelled_at IS NOT NULL`) | Terminal-status filters. |
-| `markets_orderbook_address_unique` (partial UNIQUE: `orderbook_address IS NOT NULL`) | Pins the per-market invariant; relied on by `/api/v1/orders`'s all-markets join. |
+| `markets_orderbook_address_unique` (partial UNIQUE: `orderbook_address IS NOT NULL`) | Pins the per-market invariant; relied on by `/api/v1/prediction/orders`'s all-markets join. |
 
 ### `market_outcomes`
 
@@ -217,8 +217,8 @@ Index: `market_outcomes_market_id_fk_idx` speeds up loading all outcome rows for
 
 ### `live_orders`
 
-Per-order read model backing `/api/v1/depth` and account-scoped
-`GET /api/v1/orders`. One row per chain-side order, mutated in place as
+Per-order read model backing `/api/v1/prediction/depth` and account-scoped
+`GET /api/v1/prediction/orders`. One row per chain-side order, mutated in place as
 `OrderPlaced`, `OrderFilled`, and `OrderCancelled` events arrive. Rows are never
 deleted — `FILLED` / `CANCELLED` entries remain so that history queries and the depth
 handler (`max(last_chain_order)` across **all** rows for the `(orderbook, outcome)` pair)
@@ -232,14 +232,14 @@ both see them.
 | `is_buy` | `boolean` | Side. `true` = bid, `false` = ask. |
 | `price` | `numeric(78,0)` | Order price as the contract emitted it — raw uint256 in **basis points** (probability × `FULL_PERCENT` = 10 000). Decoded to a decimal at API render time (÷ `FULL_PERCENT`, formatted at `price_precision`). |
 | `amount_initial` | `numeric(78,0)` | Original order quantity from `OrderBook.OrderPlaced`, in **raw token atoms** (× `10^decimals`). Used with `amount_remaining` to render `origQty` / `executedQty` (decoded ÷ `10^decimals`, formatted at `quantity_precision`) in account order endpoints. |
-| `amount_remaining` | `numeric(78,0)` | Quantity not yet filled. Set by the `OrderPlaced` event and decremented by the `OrderFilled` event. `OrderCancelled` preserves the current value as the cancelled remainder so `/api/v1/orders.executedQty` can be derived as `amount_initial - amount_remaining`; depth ignores the row because `status != 'OPEN'`. See the [orders cancel-remainder cutover note](../migrations/orders-cancel-remainder-cutover.md) for data-bearing deployment guidance. |
+| `amount_remaining` | `numeric(78,0)` | Quantity not yet filled. Set by the `OrderPlaced` event and decremented by the `OrderFilled` event. `OrderCancelled` preserves the current value as the cancelled remainder so `/api/v1/prediction/orders.executedQty` can be derived as `amount_initial - amount_remaining`; depth ignores the row because `status != 'OPEN'`. See the [orders cancel-remainder cutover note](../migrations/orders-cancel-remainder-cutover.md) for data-bearing deployment guidance. |
 | `client_order_id` | `text` | Optional client-supplied id. |
 | `owner_pn_address` | `text` | Trading PrivateNote address that owns the order. Initially NULL from `OrderBook.OrderPlaced`; attached by `PrivateNote.OrderPlacedConfirmed` using the event source address. NULL rows can still contribute to public depth, but cannot appear in account-scoped order responses. |
 | `status` | `text` CHECK `IN ('OPEN', 'FILLED', 'CANCELLED')` | Order lifecycle. Depth aggregation filters on `status = 'OPEN' AND amount_remaining > 0`. The CHECK is extended to include `'REJECTED'` by the contracts-side follow-up documented in [read-api.md §REJECTED — future work](read-api.md#rejected--future-work); until then no row carries that value. |
 | `last_chain_order` | `text` NOT NULL | Chain-order key (`msg_chain_order` from the gateway) of the most recent OrderBook event that touched this order. Lex-monotonic via `greatest(existing, new)` on OrderBook writes. Feeds `lastUpdateId` in depth responses as a STRING. |
-| `chain_created_at` | `timestamptz` | On-chain block time of the originating `OrderBook.OrderPlaced`. Drives `time` in `/api/v1/orders`. Display-only. NULL for pre-migration rows. |
-| `chain_updated_at` | `timestamptz` | On-chain block time of the most recent order book event that affected the order — OrderPlaced, OrderFilled, OrderCancelled. Advanced via greatest(...). Drives updateTime in /api/v1/orders. Display-only. NULL for pre-migration rows. |
-| `placed_chain_order` | `text not null` | `msg_chain_order` of the `OrderPlaced` event that created the row. First-write-wins (`coalesce` on conflict). Sole sort key + cursor for `/api/v1/orders` (DESC). |
+| `chain_created_at` | `timestamptz` | On-chain block time of the originating `OrderBook.OrderPlaced`. Drives `time` in `/api/v1/prediction/orders`. Display-only. NULL for pre-migration rows. |
+| `chain_updated_at` | `timestamptz` | On-chain block time of the most recent order book event that affected the order — OrderPlaced, OrderFilled, OrderCancelled. Advanced via greatest(...). Drives updateTime in /api/v1/prediction/orders. Display-only. NULL for pre-migration rows. |
+| `placed_chain_order` | `text not null` | `msg_chain_order` of the `OrderPlaced` event that created the row. First-write-wins (`coalesce` on conflict). Sole sort key + cursor for `/api/v1/prediction/orders` (DESC). |
 | `created_at` / `updated_at` | `timestamptz` | Bookkeeping. |
 
 Index: `live_orders_open_book_idx` — partial index on `(orderbook_address, outcome_id, is_buy, price DESC)` with predicate `status = 'OPEN'`. Sized for the depth query: top-N price levels per side and outcome.
@@ -247,7 +247,7 @@ Index: `live_orders_open_book_idx` — partial index on `(orderbook_address, out
 Index: `live_orders_owner_idx` — partial index on `(owner_pn_address, placed_chain_order DESC)`
 with predicate `owner_pn_address IS NOT NULL AND chain_created_at IS NOT NULL`.
 
-Serves as the seek path for the cursor-based `/api/v1/orders` query (DESC by chain-order): a single-
+Serves as the seek path for the cursor-based `/api/v1/prediction/orders` query (DESC by chain-order): a single-
 column lexicographic range scan over `placed_chain_order`. The partial predicate confines the index
 to owner-attributed rows whose timestamps are renderable. Status filtering (`OPEN` vs `FILLED` vs
 `CANCELLED` vs the future `REJECTED`) is intentionally a heap-side predicate so that one index
@@ -264,23 +264,23 @@ Data-bearing cutover guidance lives in
 
 ### `trades`
 
-Append-only public trade tape backing `GET /api/v1/trades`. One row per maker↔taker
+Append-only public trade tape backing `GET /api/v1/prediction/trades`. One row per maker↔taker
 match, written by the `OrderBook.OrderFilled` projector on the **taker-side** event only
 (`isTaker = true`) — the maker-side event mutates `live_orders` but writes no `trades`
 row, so a match is recorded exactly once. Rows are immutable once written, except a
 first-write-wins fill of a `NULL` `chain_time` on replay; never deleted. Write-side
 derivation in [indexer.md](indexer.md#projection--public-trades); read side in
-[read-api.md](read-api.md#apiv1trades).
+[read-api.md](read-api.md#apiv1predictiontrades).
 
 | Column | Type | Notes |
 | --- | --- | --- |
-| `trade_id` | `text` PK | The taker-side `OrderFilled` event's chain-order key (`msg_chain_order` from the gateway, copied from [`raw_events.chain_order`](#raw_events)). Globally unique per match and lex-sortable — the sole sort key and identity for `/api/v1/trades` (DESC). The identical value is specified to surface as `orderUpdate`'s `t` field for the same fill ([api-spec.md](../api-spec.md#recent-trades)). |
+| `trade_id` | `text` PK | The taker-side `OrderFilled` event's chain-order key (`msg_chain_order` from the gateway, copied from [`raw_events.chain_order`](#raw_events)). Globally unique per match and lex-sortable — the sole sort key and identity for `/api/v1/prediction/trades` (DESC). The identical value is specified to surface as `orderUpdate`'s `t` field for the same fill ([api-spec.md](../api-spec.md#prediction-trades)). |
 | `orderbook_address` | `text` NOT NULL | OrderBook contract address. With `outcome_id`, scopes the tape to one market outcome. |
 | `outcome_id` | `integer` NOT NULL | Which outcome the match is on. |
 | `price` | `numeric(78,0)` NOT NULL | Match (clearing) price from `OrderFilled.clearingPrice` — raw uint256 **basis points** (probability × `FULL_PERCENT` = 10 000). Decoded ÷ `FULL_PERCENT`, formatted at `price_precision`, at API render. |
 | `qty` | `numeric(78,0)` NOT NULL | Matched quantity from `OrderFilled.filledAmount` — raw **token atoms** (× `10^decimals`). Decoded ÷ `10^decimals`, formatted at `quantity_precision`. `quoteQty` is derived at render as `price * qty / FULL_PERCENT` (the contract's integer-division notional), not stored. |
 | `is_buyer_maker` | `boolean` NOT NULL | Trade direction, derived from the taker order's side: taker selling ⇒ the buyer is the maker ⇒ `true`; taker buying ⇒ `false`. Surfaces as `isBuyerMaker`. |
-| `chain_time` | `timestamptz` | On-chain block time of the taker `OrderFilled` event ([`raw_events.created_at_chain`](#raw_events)). Drives `time` (Unix ms) in trade responses. NULL when the gateway omitted `created_at`; such rows are filtered out of the read query, matching `live_orders` / `/api/v1/orders`. |
+| `chain_time` | `timestamptz` | On-chain block time of the taker `OrderFilled` event ([`raw_events.created_at_chain`](#raw_events)). Drives `time` (Unix ms) in trade responses. NULL when the gateway omitted `created_at`; such rows are filtered out of the read query, matching `live_orders` / `/api/v1/prediction/orders`. |
 | `created_at` | `timestamptz` | Bookkeeping (indexer ingestion wall-clock). |
 
 Index: `trades_tape_idx` — `(orderbook_address, outcome_id, trade_id DESC)`. Backs the newest-first per-outcome read (`ORDER BY trade_id DESC LIMIT $limit`) as an index range scan. `trades` is insert-only; a replayed insert conflicts on `trade_id` and only coalesces a `NULL` `chain_time` (first-write-wins), so reprojection from `raw_events` is idempotent.
@@ -292,7 +292,7 @@ Recovery notes for on-call:
 
 ### `order_book_snapshots`
 
-Reserved table for cached depth snapshots. Not used by the current depth handler — `/api/v1/depth` aggregates `live_orders` on every request. Kept in the schema for a future cache-warming path; safe to ignore until then.
+Reserved table for cached depth snapshots. Not used by the current depth handler — `/api/v1/prediction/depth` aggregates `live_orders` on every request. Kept in the schema for a future cache-warming path; safe to ignore until then.
 
 | Column | Type | Notes |
 | --- | --- | --- |

--- a/docs/tech-specs/indexer.md
+++ b/docs/tech-specs/indexer.md
@@ -86,7 +86,7 @@ When `LOG_DIR` is set, the projector's "no handler for event type" warnings are 
 
 ## Projection — lifecycle events
 
-Lifecycle events drive transitions on [`markets`](data-schema.md#markets) and the [`oracles`](data-schema.md#oracles) / [`oracle_event_lists`](data-schema.md#oracle_event_lists) / [`oracle_events`](data-schema.md#oracle_events) hierarchy. Each projector identifies its row by `pmp_address` (or the relevant parent address); if that row does not exist yet, the projector returns `Deferred` so the projection loop will retry once the parent event has landed.
+Lifecycle events drive transitions on [`markets`](data-schema.md#prediction-markets) and the [`oracles`](data-schema.md#oracles) / [`oracle_event_lists`](data-schema.md#oracle_event_lists) / [`oracle_events`](data-schema.md#oracle_events) hierarchy. Each projector identifies its row by `pmp_address` (or the relevant parent address); if that row does not exist yet, the projector returns `Deferred` so the projection loop will retry once the parent event has landed.
 
 | Event | Read-model effect |
 | --- | --- |
@@ -94,7 +94,7 @@ Lifecycle events drive transitions on [`markets`](data-schema.md#markets) and th
 | `Oracle.OracleEventListDeployed` | Inserts [`oracle_event_lists`](data-schema.md#oracle_event_lists) under the parent oracle, including the per-list `description` carried by the event. The field is read **strictly** (a missing `description` fails the projection) and written via `coalesce` so replays do not clobber it; the column is `NOT NULL`. |
 | `OracleEventList.EventAdded` | Upserts [`oracle_events`](data-schema.md#oracle_events) with `event_name`, `oracle_fee`, `deadline`. Does NOT carry `describe`, `trust_addr`, or `outcome_names_jsonb` — those come from the OracleEventList reconciler. |
 | `OracleEventList.EventConfirmed` | Stamps `oracle_events.confirmed_pmp_address` and `confirmed_at`. Links an event to the PMP that will market it. |
-| `PrivateNote.PMPDeployed` | Inserts a row in [`markets`](data-schema.md#markets) with `pmp_address`, `event_id`, `token_type`, `token_code`. Lifecycle columns (`stake_*`, `result_*`, `frozen_at`, etc.) stay NULL — they belong to later events. The row is invisible to the API until the reconciler stamps `last_reconciled_at`. |
+| `PrivateNote.PMPDeployed` | Inserts a row in [`markets`](data-schema.md#prediction-markets) with `pmp_address`, `event_id`, `token_type`, `token_code`. Lifecycle columns (`stake_*`, `result_*`, `frozen_at`, etc.) stay NULL — they belong to later events. The row is invisible to the API until the reconciler stamps `last_reconciled_at`. |
 | `PMP.TimingsSet` | Updates `stake_start`, `stake_end`, `result_start`, `result_end`, sets `approved = true`. May fire repeatedly while `now < resultStart` — keep the latest by block time. This projector is the **sole writer** of the four timing columns. |
 | `PMP.PoolsFrozen` | Sets `frozen_at` via `coalesce` (never overwritten). This is the on-chain signal that the OrderBook contract has been deployed (see [dex-events-routing.md](../dex-events-routing.md): "after deploy OrderBook"). |
 | `PMP.Resolved` | Sets `resolved_at` and `resolved_outcome_id`. |
@@ -104,8 +104,8 @@ Lifecycle events drive transitions on [`markets`](data-schema.md#markets) and th
 ## Projection — order events
 
 OrderBook events drive [`live_orders`](data-schema.md#live_orders), the
-per-order read model backing `/api/v1/depth` and account-scoped
-`GET /api/v1/orders`.
+per-order read model backing `/api/v1/prediction/depth` and account-scoped
+`GET /api/v1/prediction/orders`.
 
 Three OrderBook events mutate order book state, one
 PrivateNote confirmation event attaches ownership for private reads, and five OrderBook
@@ -113,7 +113,7 @@ events are observability-only.
 
 | Event | Effect |
 | --- | --- |
-| `OrderBook.OrderPlaced` | Upserts into `live_orders` with `status = 'OPEN'`, full `amount_initial`, and full `amount_remaining`. `owner_pn_address` remains NULL until the matching PrivateNote confirmation arrives. `last_chain_order` is set to the event’s `msg_chain_order`. On conflict the upsert is `WHERE`-guarded against terminal rows (`FILLED` / `CANCELLED` / `REJECTED`): an isolated replay landing on a closed row is a no-op rather than reopening to OPEN, surfaced at `warn!` with `msg_id` / `chain_order` for triage. The handler sets: `chain_created_at` using first-write-wins semantics via `coalesce(...) on conflict` — the creation timestamp must never move once recorded; `chain_updated_at` using `greatest(...) on conflict`; `placed_chain_order` using `coalesce(live_orders.placed_chain_order, excluded.placed_chain_order)` from the event’s msg_chain_order. `placed_chain_order` is the sole sort key for `/api/v1/orders` and never changes once recorded, matching the first-write-wins semantics of chain_created_at. |
+| `OrderBook.OrderPlaced` | Upserts into `live_orders` with `status = 'OPEN'`, full `amount_initial`, and full `amount_remaining`. `owner_pn_address` remains NULL until the matching PrivateNote confirmation arrives. `last_chain_order` is set to the event’s `msg_chain_order`. On conflict the upsert is `WHERE`-guarded against terminal rows (`FILLED` / `CANCELLED` / `REJECTED`): an isolated replay landing on a closed row is a no-op rather than reopening to OPEN, surfaced at `warn!` with `msg_id` / `chain_order` for triage. The handler sets: `chain_created_at` using first-write-wins semantics via `coalesce(...) on conflict` — the creation timestamp must never move once recorded; `chain_updated_at` using `greatest(...) on conflict`; `placed_chain_order` using `coalesce(live_orders.placed_chain_order, excluded.placed_chain_order)` from the event’s msg_chain_order. `placed_chain_order` is the sole sort key for `/api/v1/prediction/orders` and never changes once recorded, matching the first-write-wins semantics of chain_created_at. |
 | `OrderBook.OrderFilled` | For a non-terminal row: decrements `amount_remaining` by `filledAmount`, flips `status` to `FILLED` when the remainder reaches zero, advances `last_chain_order` via `greatest(existing, new)`, advances `chain_updated_at` via `greatest`. For a row whose prior status is already terminal (`FILLED` / `CANCELLED` / `REJECTED`) all four mutation columns (`amount_remaining`, `status`, `last_chain_order`, `chain_updated_at`) are CASE-gated to leave the row unchanged; the event is logged at `warn!` and the projector still reports `Applied`. |
 | `OrderBook.OrderCancelled` | For a non-terminal row: preserves `amount_remaining` as the unfilled cancelled remainder, flips `status` to `CANCELLED`, advances `last_chain_order` and `chain_updated_at` via `greatest`. For a row whose prior status is already terminal (`FILLED` / `REJECTED`) all three mutation columns are CASE-gated to leave the row unchanged; the event is logged at `warn!` and the projector still reports `Applied`. The terminal-state guard prevents a late cancel from demoting `FILLED` or rewriting `REJECTED`. |
 | `PrivateNote.OrderPlacedConfirmed` | Updates the matching `(orderBook, orderId)` row with `owner_pn_address = event.src`, where `event.src` is the authenticated account's trading PrivateNote address. If the OrderBook row has not arrived yet, the confirmation is deferred and replayed later. This ownership update does not advance `last_chain_order`, so public depth cursors continue to represent OrderBook activity only. Refuses to overwrite an already-attached `owner_pn_address`; that path is reported as `Applied` (no-op). |
@@ -125,11 +125,11 @@ Event ordering is anchored on `raw_events.chain_order` (set from the GraphQL gat
 
 ## Projection — public trades
 
-The public trade tape behind [`GET /api/v1/trades`](../api-spec.md#recent-trades) is built from the
+The public trade tape behind [`GET /api/v1/prediction/trades`](../api-spec.md#prediction-trades) is built from the
 same `OrderBook.OrderFilled` event that drives `live_orders`, written into a separate
 append-only `trades` table. Only the `tradeId` derivation is specified here; the table
 shape lives in [data-schema.md](data-schema.md#trades) and the HTTP layer in
-[read-api.md](read-api.md#apiv1trades).
+[read-api.md](read-api.md#apiv1predictiontrades).
 
 A single match emits **two** `OrderFilled` events — one for the resting (maker) order
 and one for the aggressor (taker) order, distinguished by the boolean `isTaker` field.
@@ -170,7 +170,7 @@ directly, never by clearing `processed_at`; see the recovery notes in
 event observed before its parent `OrderPlaced` is `Deferred` and retried.
 
 The same canonical `tradeId` is the value the private `orderUpdate` WebSocket frame must
-surface as `t` (see [api-spec.md](../api-spec.md#recent-trades)); associating it with the
+surface as `t` (see [api-spec.md](../api-spec.md#prediction-trades)); associating it with the
 maker side's frame as well is part of that stream's implementation and is out of scope
 here.
 
@@ -180,7 +180,7 @@ Two reconcilers fill metadata that the event stream alone does not carry. Both r
 
 ### Market reconciler
 
-For each [`markets`](data-schema.md#markets) row that needs catch-up, the reconciler:
+For each [`markets`](data-schema.md#prediction-markets) row that needs catch-up, the reconciler:
 
 1. Fetches the PMP account BOC from chain.
 2. Runs `PMP.getDetails()` off-chain through the local TVM emulator (`crates/infrastructure/src/tvm_runner.rs`).
@@ -230,7 +230,7 @@ The projection loop (`indexer_repo.rs::run_reprojection_loop`, draining via `rep
 
 A batch is drained optimistically in a single transaction with **no per-row savepoint**, so an applied row costs only its projector statements — not an extra `SAVEPOINT`/`RELEASE` round-trip pair, which matters when the database is far (high per-round-trip latency). If a projector returns `Err`, that transaction is rolled back untouched and the same range is replayed with per-row savepoints, which applies the clean rows and leaves the failing one pending — the identical outcome to savepointing every row, paid for only when a failure actually occurs. The savepointed replay is paid only on passes that hit a projector error — in practice the periodic retry pass re-attempting a stuck row, though a newly captured row that errors on first sight also drops its forward pass to the fallback. A clean forward drain stays on the savepoint-free fast path.
 
-Reconciler-side failures use a separate mechanism — `last_reconcile_failed_at` and `reconcile_attempts` on the [`markets`](data-schema.md#markets) and [`oracle_event_lists`](data-schema.md#oracle_event_lists) rows. The 5-minute backoff window prevents a permanently broken `getDetails()` from blocking the batch every tick.
+Reconciler-side failures use a separate mechanism — `last_reconcile_failed_at` and `reconcile_attempts` on the [`markets`](data-schema.md#prediction-markets) and [`oracle_event_lists`](data-schema.md#oracle_event_lists) rows. The 5-minute backoff window prevents a permanently broken `getDetails()` from blocking the batch every tick.
 
 ## Metrics
 

--- a/docs/tech-specs/read-api.md
+++ b/docs/tech-specs/read-api.md
@@ -12,17 +12,17 @@ Implementation-facing requirements for the HTTP layer that serves the market-dat
 
 **Chain time** — `raw_events.created_at_chain` of the event that produced a state transition. Used for response `time` and `updateTime` so they are stable under indexer backlog.
 
-**Market row** — one row in the `markets` table. It represents one PMP contract and is the main source for `/api/v1/markets`.
+**Market row** — one row in the `markets` table. It represents one PMP contract and is the main source for `/api/v1/prediction/markets`.
 
-**Reconciled market** — a market row with `last_reconciled_at IS NOT NULL`. This means the market reconciler has already read the PMP state and filled the fields required for public responses. `/api/v1/markets` hides markets until this is true.
+**Reconciled market** — a market row with `last_reconciled_at IS NOT NULL`. This means the market reconciler has already read the PMP state and filled the fields required for public responses. `/api/v1/prediction/markets` hides markets until this is true.
 
 **Lifecycle status** — the public market phase returned as `status`: `PENDING`, `UPCOMING`, `STAKING`, `AWAITING_FREEZE`, `TRADING`, `RESOLVING`, `RESOLVED`, `CANCELLED`, or `EXPIRED`. It is computed by the API from the market row and current request time; it is not stored as a separate database column.
 
-**serverTime** — the unix-seconds timestamp captured once at the start of a `/api/v1/markets` request. The API returns it in the response and uses the same value to compute lifecycle status.
+**serverTime** — the unix-seconds timestamp captured once at the start of a `/api/v1/prediction/markets` request. The API returns it in the response and uses the same value to compute lifecycle status.
 
-**Depth** — the `/api/v1/depth` response for one market outcome: sorted bid and ask price levels plus `lastUpdateId`. It is built from `live_orders`, not by querying the OrderBook contract during the HTTP request.
+**Depth** — the `/api/v1/prediction/depth` response for one market outcome: sorted bid and ask price levels plus `lastUpdateId`. It is built from `live_orders`, not by querying the OrderBook contract during the HTTP request.
 
-**Trade tape** — the `/api/v1/trades` response for one market outcome: a newest-first list of maker↔taker matches built from the append-only `trades` table, not by querying the OrderBook contract during the HTTP request.
+**Trade tape** — the `/api/v1/prediction/trades` response for one market outcome: a newest-first list of maker↔taker matches built from the append-only `trades` table, not by querying the OrderBook contract during the HTTP request.
 
 **DTO** — Data Transfer Object. In this document it means the API response object after the backend has assembled it from database rows, but before it is serialized to JSON and sent to the client.
 
@@ -30,19 +30,19 @@ Implementation-facing requirements for the HTTP layer that serves the market-dat
 
 ## Market identity
 
-The backend treats `marketAddress` as the PMP address. `orderBookAddress` is the deterministic address returned by `PMP.getOrderBookAddress()` and is stamped on the first successful reconciler pass — pre-`PoolsFrozen` rows already carry it. The pre-reconcile window between `PMPDeployed` and the first reconciler pass is the only state where the column is legitimately null, and such rows are hidden from the API by the `last_reconciled_at IS NOT NULL` visibility filter. The write-side flow is described in [indexer.md](indexer.md#market-reconciler). Clients MUST use `status` to determine whether the order book is currently available for trading — a non-null `orderBookAddress` does not by itself imply the book is open.
+The backend treats `predictionMarketAddress` as the PMP address. `predictionOrderBookAddress` is the deterministic address returned by `PMP.getOrderBookAddress()` and is stamped on the first successful reconciler pass — pre-`PoolsFrozen` rows already carry it. The pre-reconcile window between `PMPDeployed` and the first reconciler pass is the only state where the column is legitimately null, and such rows are hidden from the API by the `last_reconciled_at IS NOT NULL` visibility filter. The write-side flow is described in [indexer.md](indexer.md#market-reconciler). Clients MUST use `status` to determine whether the order book is currently available for trading — a non-null `predictionOrderBookAddress` does not by itself imply the book is open.
 
-## `/api/v1/markets`
+## `/api/v1/prediction/markets`
 
 Lifecycle status is not stored as a separate database column. The API computes it for each request from the indexed market row and a single unix-seconds `now` value. The same `now` is returned as `serverTime` and used for status calculation, so one response cannot mix timestamps from both sides of a lifecycle boundary.
 
 ### Visibility filter
 
-The SQL query behind `GET /api/v1/markets` includes `WHERE m.last_reconciled_at IS NOT NULL`. Markets that the indexer has discovered (the `PMPDeployed` event arrived) but not yet reconciled are hidden — clients only see markets the backend can describe fully. See [indexer.md](indexer.md#visibility-gate) for the symmetric write-side rule.
+The SQL query behind `GET /api/v1/prediction/markets` includes `WHERE m.last_reconciled_at IS NOT NULL`. Markets that the indexer has discovered (the `PMPDeployed` event arrived) but not yet reconciled are hidden — clients only see markets the backend can describe fully. See [indexer.md](indexer.md#visibility-gate) for the symmetric write-side rule.
 
 ### Status derivation
 
-Source: a row in [`markets`](data-schema.md#markets) plus the request `now`. Order of checks (terminal events take precedence over time-derived phases):
+Source: a row in [`markets`](data-schema.md#prediction-markets) plus the request `now`. Order of checks (terminal events take precedence over time-derived phases):
 
 1. `cancelled_at IS NOT NULL` OR `is_cancelled` → `CANCELLED`.
 2. `resolved_at IS NOT NULL` → `RESOLVED`.
@@ -105,46 +105,46 @@ The matching write-side rules are in [indexer.md](indexer.md#schema-invariants--
 | --- | --- | --- |
 | Market not found / not yet reconciled | `InvalidMarketOrSymbol` | 404 |
 | Invalid `status` / `sort` enum value | `InvalidParameter` | 400 |
-| Mutually exclusive params (`marketAddress` together with list filters) | `MissingParameter` | 400 |
+| Mutually exclusive params (`predictionMarketAddress` together with list filters) | `MissingParameter` | 400 |
 | Corrupted cursor | `InvalidParameter` (from cursor decode) | 400 |
 | Invariant violation on built DTO | `MarketInconsistent` | 503 |
 
 ## `/api/v1/oracles`
 
-Public discovery endpoint: lists oracles, their event lists, and the events those lists currently offer for market creation. Public contract: [api-spec §Oracles](../api-spec.md#oracles). No authentication — the route is mounted alongside `/api/v1/markets` and `/api/v1/depth`, outside the auth subrouter. The Postgres source is [`oracles`](data-schema.md#oracles) ⨝ [`oracle_event_lists`](data-schema.md#oracle_event_lists) ⨝ [`oracle_events`](data-schema.md#oracle_events); the write side (projectors plus the OracleEventList reconciler) is in [indexer.md](indexer.md). The endpoint never queries the oracle contracts at request time — it reads the indexed discovery read-model.
+Public discovery endpoint: lists oracles, their event lists, and the events those lists currently offer for market creation. Public contract: [api-spec §Oracles](../api-spec.md#oracles). No authentication — the route is mounted alongside `/api/v1/prediction/markets` and `/api/v1/prediction/depth`, outside the auth subrouter. The Postgres source is [`oracles`](data-schema.md#oracles) ⨝ [`oracle_event_lists`](data-schema.md#oracle_event_lists) ⨝ [`oracle_events`](data-schema.md#oracle_events); the write side (projectors plus the OracleEventList reconciler) is in [indexer.md](indexer.md). The endpoint never queries the oracle contracts at request time — it reads the indexed discovery read-model.
 
 The response is grouped oracle → event list → event. Pagination is **by oracle** (`limit` counts oracles); an oracle's full set of event lists and available events is always returned whole — there is no inner pagination in v1.
 
 ### serverTime
 
-`serverTime` is the unix-seconds timestamp captured once at handler entry. The same value is the `now` used for the deadline-availability predicate, so one response cannot mix an availability boundary computed from a different clock reading than the one it reports — the same discipline `/api/v1/markets` applies to lifecycle status.
+`serverTime` is the unix-seconds timestamp captured once at handler entry. The same value is the `now` used for the deadline-availability predicate, so one response cannot mix an availability boundary computed from a different clock reading than the one it reports — the same discipline `/api/v1/prediction/markets` applies to lifecycle status.
 
 ### Available events
 
 An `oracle_events` row is **available** (eligible to surface) when all hold:
 
 - `is_deleted = false` — not soft-deleted. No projector sets this `true` today: the OracleEventList contract emits no delete/cancel event, so the conjunct is currently a no-op kept for forward-compatibility.
-- `deadline > now` — the event can still be used for a new market. The boundary is strict: at `now == deadline` the event is past and hidden, mirroring the `now >= result_end → EXPIRED` boundary in `/api/v1/markets`.
-- `meta_reconciled_at IS NOT NULL` — the OracleEventList reconciler has filled the metadata that lives only in the `_events` getter (`describe`, `trust_addr`, and `outcome_names_jsonb`). This is the symmetric analogue of the `last_reconciled_at IS NOT NULL` visibility gate on `/api/v1/markets`: an event is hidden until the backend can describe it fully, so `outcomes` is never served empty merely because reconciliation has not run. `event_name`, `oracle_fee`, and `deadline` arrive earlier via the `EventAdded` projector, but the reconciler-only fields gate visibility.
+- `deadline > now` — the event can still be used for a new market. The boundary is strict: at `now == deadline` the event is past and hidden, mirroring the `now >= result_end → EXPIRED` boundary in `/api/v1/prediction/markets`.
+- `meta_reconciled_at IS NOT NULL` — the OracleEventList reconciler has filled the metadata that lives only in the `_events` getter (`describe`, `trust_addr`, and `outcome_names_jsonb`). This is the symmetric analogue of the `last_reconciled_at IS NOT NULL` visibility gate on `/api/v1/prediction/markets`: an event is hidden until the backend can describe it fully, so `outcomes` is never served empty merely because reconciliation has not run. `event_name`, `oracle_fee`, and `deadline` arrive earlier via the `EventAdded` projector, but the reconciler-only fields gate visibility.
 
 Event lists with no available events, and oracles with no non-empty event lists, are omitted (see [api-spec §Oracles](../api-spec.md#oracles): "Event lists and oracles with no remaining events are omitted").
 
 ### Filters
 
-All four query filters combine freely — there is no mutually-exclusive mode like `/api/v1/markets`'s `marketAddress`:
+All four query filters combine freely — there is no mutually-exclusive mode like `/api/v1/prediction/markets`'s `predictionMarketAddress`:
 
 | Param | Predicate |
 | --- | --- |
 | `oracleAddress` | `oracles.address = $addr`, applied to oracle selection only. Blank / whitespace is treated as absent. |
 | `eventId` | The client passes the hex form (as rendered in `eventId` responses); the read path converts it to decimal and matches `oracle_events.internal_id_in_eventlist = $decimal::numeric`. With this filter the `events[]` arrays contain only the matching event, and lists / oracles without it are omitted. Un-decodable hex → `InvalidParameter` / 400. |
 | `deadlineBefore` | `oracle_events.deadline < $deadlineBefore` (unix seconds), combined with the availability `deadline > now`, i.e. `now < deadline < deadlineBefore`. Non-numeric → `InvalidParameter` / 400. |
-| `limit` | Oracle page size. Default 50, clamped to `[1, 200]`; non-numeric → `InvalidParameter` / 400. Clamping (rather than rejecting) out-of-range values matches `/api/v1/markets`. |
+| `limit` | Oracle page size. Default 50, clamped to `[1, 200]`; non-numeric → `InvalidParameter` / 400. Clamping (rather than rejecting) out-of-range values matches `/api/v1/prediction/markets`. |
 
 The availability predicate plus the `eventId` / `deadlineBefore` event-level filters form a single shared SQL fragment, bound identically into the Phase-1 `EXISTS` sub-query and the Phase-2 fetch (see [§ Query](#query)). Sharing one fragment is load-bearing: were the two to diverge, Phase 1 could select an oracle whose events Phase 2 then filters away, emitting an empty oracle and inflating `hasMore` — the same class of bug the markets `STATUS_CASE` sharing prevents.
 
 ### Query
 
-Two round-trips, mirroring `/api/v1/markets`'s `fetch_listing` → `fetch_outcomes` shape:
+Two round-trips, mirroring `/api/v1/prediction/markets`'s `fetch_listing` → `fetch_outcomes` shape:
 
 1. **Oracle page.** Select the next page of oracle ids, keyset-ordered by `(name, id)`:
 
@@ -201,18 +201,18 @@ Field mapping (see [api-spec §Oracles](../api-spec.md#oracles) for the public s
 | `eventLists[].index` | `oracle_event_lists.list_index` | |
 | `eventLists[].address` | `oracle_event_lists.address` | |
 | `eventLists[].description` | `oracle_event_lists.description` | `NOT NULL` column written by the deploy projector from the `OracleEventListDeployed` payload (read strictly). The public field is therefore a plain `STRING` (possibly empty, never null). |
-| `events[].eventId` | `oracle_events.internal_id_in_eventlist` → `numeric_to_hex` | The same hex rendering `/api/v1/markets` uses for `event.eventId`, so the value round-trips back into the `eventId` filter. |
+| `events[].eventId` | `oracle_events.internal_id_in_eventlist` → `numeric_to_hex` | The same hex rendering `/api/v1/prediction/markets` uses for `event.eventId`, so the value round-trips back into the `eventId` filter. |
 | `events[].eventName` | `oracle_events.event_name` | `EventAdded` projector. |
 | `events[].description` | `oracle_events.describe` | Reconciler-only; `null` until reconciled to a non-null value. |
 | `events[].oracleFee.asset` | literal `"SHELL"` | The oracle contracts denominate fees in SHELL today; not stored per-event. A second fee asset would turn this into a `ref_tokens` lookup. |
-| `events[].oracleFee.amount` | `oracle_events.oracle_fee::text` | Raw chain integer as a decimal string — **not** scaled, matching the unscaled `fee` rendering in `/api/v1/markets`'s `event.oracles[]`. |
+| `events[].oracleFee.amount` | `oracle_events.oracle_fee::text` | Raw chain integer as a decimal string — **not** scaled, matching the unscaled `fee` rendering in `/api/v1/prediction/markets`'s `event.oracles[]`. |
 | `events[].deadline` | `oracle_events.deadline` | Unix seconds. |
 | `events[].trustAddress` | `oracle_events.trust_addr` | Reconciler-only; the raw `0x…` form returned by the `_events` getter. `null` when absent on chain. |
 | `events[].outcomes` | `oracle_events.outcome_names_jsonb` | Decoded to `[{outcomeId, outcomeName}]` sorted by `outcomeId` ascending. |
 
 `outcome_names_jsonb` holds the on-chain `outcomeNames` map as `{"<outcomeId>": "<name>"}`. The decoder parses each key as `u32`, sorts ascending, and rejects a malformed map (non-object, non-numeric or out-of-`u32` key, non-string value) as `MarketInconsistent` — see fail-closed below. A legitimately empty `{}` (the chain published no labels) yields an empty `outcomes` array, not an error.
 
-The top-level response is returned directly (no envelope), like `/api/v1/markets`: `{ serverTime, nextCursor, hasMore, oracles }`.
+The top-level response is returned directly (no envelope), like `/api/v1/prediction/markets`: `{ serverTime, nextCursor, hasMore, oracles }`.
 
 ### Pagination cursor
 
@@ -236,7 +236,7 @@ After building each oracle DTO the assembled shape is checked; any violation is 
 | Rule | Source |
 | --- | --- |
 | `outcome_names_jsonb` is a JSON object; every key parses to `u32`; every value is a string | The `_events.outcomeNames` map shape; a non-conforming blob is reconciler / ingestion corruption, not a renderable outcome set. |
-| `eventId` renders (numeric → hex conversion succeeds on `internal_id_in_eventlist`) | The same `numeric_to_hex` invariant `/api/v1/markets` enforces on `event.eventId`. |
+| `eventId` renders (numeric → hex conversion succeeds on `internal_id_in_eventlist`) | The same `numeric_to_hex` invariant `/api/v1/prediction/markets` enforces on `event.eventId`. |
 
 ### Error mapping
 
@@ -257,7 +257,7 @@ Three points decided here for the team to confirm:
 
 1. **Confirmed events are not excluded.** The default availability filter is exactly "not deleted, not past deadline" per [api-spec §Oracles](../api-spec.md#oracles); an event with `confirmed_pmp_address IS NOT NULL` (already backing a market) still lists. Rationale: `OracleEventList.confirmEvent(eventId, oracleListHash, tokenType)` is parameterized by `(oracleListHash, tokenType)`, so one event can back more than one market, and the read-model's single `confirmed_pmp_address` column cannot express "fully consumed". If product intent is "hide once used", add `confirmed_pmp_address IS NULL` to the availability predicate.
 2. **`eventLists[].description` is required (resolved).** The api-spec keeps it `STRING`; the fresh path is hardened to match — `OracleEventListDeployed` always carries `description`, the projector reads it strictly, and the column is `NOT NULL`. The value may be an empty string but is never null, so no `STRING | null` softening is needed.
-3. **`oracleFee.amount` is unscaled.** Rendered as the raw chain integer (decimal string), consistent with `/api/v1/markets`. If clients need a human-scaled amount, scale by SHELL's `ref_tokens.decimals` — deferred until a concrete need.
+3. **`oracleFee.amount` is unscaled.** Rendered as the raw chain integer (decimal string), consistent with `/api/v1/prediction/markets`. If clients need a human-scaled amount, scale by SHELL's `ref_tokens.decimals` — deferred until a concrete need.
 
 ### Test coverage
 
@@ -269,13 +269,13 @@ Three suites, the DB-backed ones gated on `TEST_DATABASE_URL`:
 
 Domain note: the unused `Oracle` / `OracleEventList` / `OracleEvent` structs in `crates/domain/src/lib.rs` predate the api-spec shape and are replaced by the response types this endpoint introduces (`OracleListing` / `OracleEventListEntry` / `OracleEventEntry` / `OracleOutcome` / `OracleFee`).
 
-## `/api/v1/depth`
+## `/api/v1/prediction/depth`
 
 Returns the top of the order book for one outcome of one market: a snapshot of resting bids and asks, the quantity available at each price level, and a sequence number the client uses to tell whether the snapshot has moved since the previous response. The endpoint never queries the contract at request time — every level shown is the projection of indexed `OrderBook` events into a per-order read-model (see [indexer.md](indexer.md#projection--order-events)).
 
 ### Resolution
 
-Resolve `(marketAddress, symbol)` to `(orderbook_address, outcome_id, price_precision, quantity_precision)` via [`markets`](data-schema.md#markets) joined with [`market_outcomes`](data-schema.md#market_outcomes). The market must already be reconciled at least once (`last_reconciled_at IS NOT NULL`); otherwise the endpoint returns `InvalidMarketOrSymbol` → 404. The symbol identifies one of the market's outcomes — depth is per-outcome, not per-market.
+Resolve `(predictionMarketAddress, symbol)` to `(orderbook_address, outcome_id, price_precision, quantity_precision)` via [`markets`](data-schema.md#prediction-markets) joined with [`market_outcomes`](data-schema.md#market_outcomes). The market must already be reconciled at least once (`last_reconciled_at IS NOT NULL`); otherwise the endpoint returns `InvalidMarketOrSymbol` → 404. The symbol identifies one of the market's outcomes — depth is per-outcome, not per-market.
 
 ### Empty-book contract
 
@@ -295,7 +295,7 @@ After the database returns, each side is re-sorted in Rust using exact-numeric `
 
 ### `lastUpdateId`
 
-`max(live_orders.last_chain_order)` over rows for this `(orderbook_address, outcome_id)` pair. `last_chain_order` is the lex-sortable chain-order string (`msg_chain_order` from the GraphQL gateway) of the most recent event that touched the row; the public `lastUpdateId` is therefore a STRING, not an integer (see [api-spec.md §Order Book](../api-spec.md#order-book)). The per-outcome scope is intentional: a single OrderBook serves multiple outcomes, and a per-orderbook cursor would let a quiet outcome inherit activity from sibling outcomes.
+`max(live_orders.last_chain_order)` over rows for this `(orderbook_address, outcome_id)` pair. `last_chain_order` is the lex-sortable chain-order string (`msg_chain_order` from the GraphQL gateway) of the most recent event that touched the row; the public `lastUpdateId` is therefore a STRING, not an integer (see [api-spec.md §Order Book](../api-spec.md#prediction-order-book)). The per-outcome scope is intentional: a single OrderBook serves multiple outcomes, and a per-orderbook cursor would let a quiet outcome inherit activity from sibling outcomes.
 
 Empty string means no OrderBook event has touched this pair yet. The value never lex-decreases between successive snapshots — `last_chain_order` is updated via `greatest(existing, new)` on the write side, and the reproject loop applies events in `chain_order` so the natural arrival order is already monotonic (see [indexer.md](indexer.md#projection--order-events)).
 
@@ -304,7 +304,7 @@ Empty string means no OrderBook event has touched this pair yet. The value never
 1. `bids` sorted by price descending; `asks` ascending. Comparison is exact-numeric.
 2. Each price level surfaces as one `[price, quantity]` entry. Quantity is the sum across every resting order at that price.
 3. `lastUpdateId` is scoped to `(orderbook_address, outcome_id)`. It is an empty string when no OrderBook event has touched this pair yet, and never lex-decreases between successive snapshots.
-4. A non-null `orderBookAddress` on the underlying market is necessary for non-empty depth but not sufficient — orders only land after the `PoolsFrozen` event is observed and clients start posting.
+4. A non-null `predictionOrderBookAddress` on the underlying market is necessary for non-empty depth but not sufficient — orders only land after the `PoolsFrozen` event is observed and clients start posting.
 
 ### Error mapping
 
@@ -312,16 +312,16 @@ Empty string means no OrderBook event has touched this pair yet. The value never
 | --- | --- | --- |
 | Market unknown or pre-reconcile | `InvalidMarketOrSymbol` | 404 |
 | Reconciled market with NULL/blank `orderbook_address` | `MarketInconsistent` | 503 |
-| Missing `marketAddress` or `symbol` | `MissingParameter` | 400 |
+| Missing `predictionMarketAddress` or `symbol` | `MissingParameter` | 400 |
 | Invalid `limit` (non-numeric) | `InvalidParameter` | 400 |
 
-## `/api/v1/trades`
+## `/api/v1/prediction/trades`
 
 Returns the most recent public trades for one outcome of one market: a newest-first tape of maker↔taker matches, each carrying price, size, quote notional, direction, and chain time. The endpoint never queries the contract at request time — every trade shown is the projection of an indexed `OrderBook.OrderFilled` event into the append-only [`trades`](data-schema.md#trades) read-model (write side in [indexer.md](indexer.md#projection--public-trades)). It is public (`NONE`) and unaffected by market lifecycle status: terminal markets (`RESOLVED` / `CANCELLED` / `EXPIRED`) still serve their tape so history stays readable after the book closes.
 
 ### Resolution
 
-Resolve `(marketAddress, symbol)` to `(orderbook_address, outcome_id, price_precision, quantity_precision, decimals)` via [`markets`](data-schema.md#markets) ⨝ [`market_outcomes`](data-schema.md#market_outcomes) ⨝ [`ref_tokens`](data-schema.md#ref_tokens) — the quote-asset `decimals` feeds `quoteQty` scaling. The market must already be reconciled at least once (`last_reconciled_at IS NOT NULL`); otherwise the endpoint returns `InvalidMarketOrSymbol` → 404, the same way an unknown pair is reported. A pair that exists in `markets` but has never reconciled cannot be distinguished from one that does not exist, matching [`/api/v1/depth`](#apiv1depth). The symbol identifies one of the market's outcomes — the tape is per-outcome, not per-market.
+Resolve `(predictionMarketAddress, symbol)` to `(orderbook_address, outcome_id, price_precision, quantity_precision, decimals)` via [`markets`](data-schema.md#prediction-markets) ⨝ [`market_outcomes`](data-schema.md#market_outcomes) ⨝ [`ref_tokens`](data-schema.md#ref_tokens) — the quote-asset `decimals` feeds `quoteQty` scaling. The market must already be reconciled at least once (`last_reconciled_at IS NOT NULL`); otherwise the endpoint returns `InvalidMarketOrSymbol` → 404, the same way an unknown pair is reported. A pair that exists in `markets` but has never reconciled cannot be distinguished from one that does not exist, matching [`/api/v1/prediction/depth`](#apiv1predictiondepth). The symbol identifies one of the market's outcomes — the tape is per-outcome, not per-market.
 
 ### Empty-tape contract
 
@@ -345,15 +345,15 @@ SELECT trade_id,
  LIMIT $limit;
 ```
 
-`trades_tape_idx` (`(orderbook_address, outcome_id, trade_id DESC)`) serves this as an index range scan — the top `$limit` rows per outcome, newest first, without loading the full tape. There is no pagination cursor in v1: the public contract exposes only `limit` (see [api-spec §Recent Trades](../api-spec.md#recent-trades)), so the endpoint is a bounded newest-first window, not a keyset walk.
+`trades_tape_idx` (`(orderbook_address, outcome_id, trade_id DESC)`) serves this as an index range scan — the top `$limit` rows per outcome, newest first, without loading the full tape. There is no pagination cursor in v1: the public contract exposes only `limit` (see [api-spec §Recent Trades](../api-spec.md#prediction-trades)), so the endpoint is a bounded newest-first window, not a keyset walk.
 
-`trade_id` is the taker-side `chain_order` (`msg_chain_order` from the gateway), which is globally unique and lexicographically monotonic by gateway design — the same total-order property `/api/v1/orders` relies on for `placed_chain_order`. The text `ORDER BY trade_id DESC` therefore already yields true chain order with no tie-breaker and no Rust-side numeric re-sort (unlike depth, where price levels of differing length must be re-ranked with exact-numeric comparison).
+`trade_id` is the taker-side `chain_order` (`msg_chain_order` from the gateway), which is globally unique and lexicographically monotonic by gateway design — the same total-order property `/api/v1/prediction/orders` relies on for `placed_chain_order`. The text `ORDER BY trade_id DESC` therefore already yields true chain order with no tie-breaker and no Rust-side numeric re-sort (unlike depth, where price levels of differing length must be re-ranked with exact-numeric comparison).
 
-`chain_time IS NOT NULL` is a heap filter guarding the rare ingestion path where the gateway delivered the `OrderFilled` edge without a parseable `created_at`; such a row would otherwise crash the response decoder mapping `NULL` into the `time` `i64`. This mirrors the `chain_created_at IS NOT NULL` guard on [`/api/v1/orders`](#apiv1orders).
+`chain_time IS NOT NULL` is a heap filter guarding the rare ingestion path where the gateway delivered the `OrderFilled` edge without a parseable `created_at`; such a row would otherwise crash the response decoder mapping `NULL` into the `time` `i64`. This mirrors the `chain_created_at IS NOT NULL` guard on [`/api/v1/prediction/orders`](#apiv1predictionorders).
 
 ### Field projection
 
-`trades` holds the raw chain integers the contract emitted; the API decodes each field at render (see [api-spec §Recent Trades](../api-spec.md#recent-trades) for the public shapes):
+`trades` holds the raw chain integers the contract emitted; the API decodes each field at render (see [api-spec §Recent Trades](../api-spec.md#prediction-trades) for the public shapes):
 
 | Response field | Source | Rendering |
 | --- | --- | --- |
@@ -361,7 +361,7 @@ SELECT trade_id,
 | `price` | `price` | ÷ `FULL_PERCENT` (10 000), formatted at `price_precision` — the same price decode as depth / orders. |
 | `qty` | `qty` | ÷ `10^decimals`, formatted at `quantity_precision`. |
 | `quoteQty` | `price`, `qty` | Quote-asset notional, computed as the contract computes it: `notional_atoms = price * qty / FULL_PERCENT` (integer division, `BigUint`), then ÷ `10^decimals` formatted at the quote asset's `decimals`. Deriving from the same two raw integers — rather than storing a column — keeps the value reconciled with the on-chain notional that drove settlement; the chain emits no separate notional field. |
-| `time` | `chain_time` | Extracted to microseconds and truncated to Unix milliseconds — the same convention as `time` / `updateTime` on `/api/v1/orders`. |
+| `time` | `chain_time` | Extracted to microseconds and truncated to Unix milliseconds — the same convention as `time` / `updateTime` on `/api/v1/prediction/orders`. |
 | `isBuyerMaker` | `is_buyer_maker` | Verbatim. `true` ⇒ the resting (maker) side was the buy order and the taker sold (downtick). |
 
 The integer-division order matters: `price * qty / FULL_PERCENT` floors *after* multiplying, exactly as `OrderBook` derives the match notional, so `quoteQty` never drifts from chain by the rounding ulp a `round(price_decimal × qty_decimal)` could introduce.
@@ -369,7 +369,7 @@ The integer-division order matters: `price * qty / FULL_PERCENT` floors *after* 
 ### Page-size protocol
 
 - `limit` defaults to `20` when omitted.
-- Valid range is `[1, 1000]`. Out-of-range → `-1102` / 400; present but non-numeric → `-1130` / 400. The split (range vs parse) matches `/api/v1/orders`'s `limit` semantics rather than depth's silent clamp — the trade tape is aligned with the paginated-read family even though it carries no cursor.
+- Valid range is `[1, 1000]`. Out-of-range → `-1102` / 400; present but non-numeric → `-1130` / 400. The split (range vs parse) matches `/api/v1/prediction/orders`'s `limit` semantics rather than depth's silent clamp — the trade tape is aligned with the paginated-read family even though it carries no cursor.
 
 ### Invariants
 
@@ -381,7 +381,7 @@ The integer-division order matters: `price * qty / FULL_PERCENT` floors *after* 
 
 | Condition | `DomainError` | API code | HTTP |
 | --- | --- | --- | --- |
-| `marketAddress` or `symbol` missing or blank | `MissingParameter` | `-1102` | 400 |
+| `predictionMarketAddress` or `symbol` missing or blank | `MissingParameter` | `-1102` | 400 |
 | `limit` out of `[1, 1000]` | `MissingParameter` | `-1102` | 400 |
 | `limit` present but non-numeric | `InvalidParameter` | `-1130` | 400 |
 | Pair not found, or its market is unreconciled | `InvalidMarketOrSymbol` | `-1121` | 404 |
@@ -400,7 +400,7 @@ No read-side gate guards the projector: an empty `trades` table simply reads `[]
 
 ### Eventual consistency
 
-A just-matched trade briefly lags the fill that produced it: the row appears once the taker-side `OrderFilled` is projected (seconds, or after deferred-replay if the fill edge arrived before its parent `OrderPlaced`). This is the same indexer-backlog window `/api/v1/orders` exposes, surfaced to clients as the eventual-consistency note in [api-spec §Recent Trades](../api-spec.md#recent-trades). The endpoint reads only the indexed `trades` table — it never reaches chain at request time.
+A just-matched trade briefly lags the fill that produced it: the row appears once the taker-side `OrderFilled` is projected (seconds, or after deferred-replay if the fill edge arrived before its parent `OrderPlaced`). This is the same indexer-backlog window `/api/v1/prediction/orders` exposes, surfaced to clients as the eventual-consistency note in [api-spec §Recent Trades](../api-spec.md#prediction-trades). The endpoint reads only the indexed `trades` table — it never reaches chain at request time.
 
 ### Test coverage
 
@@ -410,16 +410,16 @@ Three suites, the DB-backed ones gated on `TEST_DATABASE_URL`:
 - Projector test (alongside the `live_orders` projector scenarios in `crates/infrastructure/tests/reprojection.rs`) — the taker-side event (`isTaker = true`) writes exactly one `trades` row and the maker-side writes none; `trade_id` equals the taker event's `chain_order`; replay is idempotent (`ON CONFLICT`); one taker crossing N makers yields N rows with N distinct `trade_id`s.
 - `services/api/tests/trades_http.rs` — happy path returns a bare JSON array newest-first through the production router; the error shapes (`-1102` missing param, `-1102` limit out of range, `-1130` non-numeric limit, `-1121` unknown pair, `-1500` inconsistent); the route is reachable without an auth envelope (public); a terminal-status market still serves its tape.
 
-## `/api/v1/orders`
+## `/api/v1/prediction/orders`
 
-`DELETE /api/v1/openOrders` (cancel-all-open) is a separate TRADE operation and is out of scope here — its tech spec lives in [write-api.md](write-api.md).
+`DELETE /api/v1/prediction/openOrders` (cancel-all-open) is a separate TRADE operation and is out of scope here — its tech spec lives in [write-api.md](write-api.md).
 
 ### Source data
 
 The endpoint reads exclusively from [`live_orders`](data-schema.md#live_orders). A row contributes to the response iff all hold:
 
 - `owner_pn_address = ctx.trading_pn.pn_address` — caller is the owner.
-- The parent market in [`markets`](data-schema.md#markets) has `last_reconciled_at IS NOT NULL` — pre-reconcile markets are hidden symmetrically with `/api/v1/markets`.
+- The parent market in [`markets`](data-schema.md#prediction-markets) has `last_reconciled_at IS NOT NULL` — pre-reconcile markets are hidden symmetrically with `/api/v1/prediction/markets`.
 - `chain_created_at IS NOT NULL AND chain_updated_at IS NOT NULL` — rows that the gateway delivered without a parseable timestamp would otherwise crash the decoder when mapping `NULL` into the `time` / `updateTime` `i64` fields. See [§ SQL](#sql) for how this is enforced and [§ Index reliance](#index-reliance) for why only the `chain_created_at` conjunct is part of the partial index.
 - The row's `status` (combined with `amount_remaining` vs `amount_initial` for OPEN rows) maps to at least one of the public statuses requested in the `status` filter — or, if `status` is omitted, all rows pass.
 
@@ -431,8 +431,8 @@ Market filter (same three shapes as before):
 
 | Inputs | Behaviour |
 | --- | --- |
-| neither `marketAddress` nor `symbol` | all-markets query, owner-scoped. |
-| both present | resolve `(marketAddress, symbol)` to `(orderbook_address, outcome_id)` via `markets ⨝ market_outcomes`. If the pair is missing or its market is not reconciled → `DomainError::InvalidMarketOrSymbol` → `-1121` / 404. |
+| neither `predictionMarketAddress` nor `symbol` | all-markets query, owner-scoped. |
+| both present | resolve `(predictionMarketAddress, symbol)` to `(orderbook_address, outcome_id)` via `markets ⨝ market_outcomes`. If the pair is missing or its market is not reconciled → `DomainError::InvalidMarketOrSymbol` → `-1121` / 404. |
 | exactly one present | `DomainError::MissingParameter` → `-1102` / 400. |
 
 The pair-resolution lookup is a separate SQL round-trip that runs before the main query so the unknown-pair case can be distinguished cleanly from "owner has no orders here". Resolution is bound by `last_reconciled_at IS NOT NULL` so a pair that exists in `markets` but has never reconciled is reported the same way as a pair that does not exist.
@@ -519,7 +519,7 @@ The handler reads `ctx` via `require_auth(depot, Permission::UserData)` and uses
 
 | Condition | `DomainError` | API code | HTTP |
 | --- | --- | --- | --- |
-| `marketAddress` / `symbol` pair is incomplete (only one present, or either is present but blank/whitespace) | `MissingParameter` | `-1102` | 400 |
+| `predictionMarketAddress` / `symbol` pair is incomplete (only one present, or either is present but blank/whitespace) | `MissingParameter` | `-1102` | 400 |
 | `limit` out of `[1, 500]` | `MissingParameter` | `-1102` | 400 |
 | `limit` present but non-numeric | `InvalidParameter` | `-1130` | 400 |
 | `cursor` is empty or whitespace-only | `MissingParameter` | `-1102` | 400 |
@@ -553,13 +553,13 @@ Status filters become heap predicates on top of the index range. Per-owner cardi
 
 The market-filter pair predicate (`orderbook_address = $X AND outcome_id = $Y`) is likewise a heap filter, matching the strategy already used for the OPEN-only variant.
 
-`live_orders_open_book_idx` (used by `/api/v1/depth`) is unaffected.
+`live_orders_open_book_idx` (used by `/api/v1/prediction/depth`) is unaffected.
 
 The data-schema doc ([`live_orders`](data-schema.md#live_orders)) is updated synchronously with the migration.
 
 ### Visibility / eventual consistency
 
-Between `OrderBook.OrderPlaced` and `PrivateNote.OrderPlacedConfirmed`, the row exists in `live_orders` with `owner_pn_address = NULL`. The partial index excludes `NULL` owners, so the row contributes to public depth but cannot appear in `/api/v1/orders`.
+Between `OrderBook.OrderPlaced` and `PrivateNote.OrderPlacedConfirmed`, the row exists in `live_orders` with `owner_pn_address = NULL`. The partial index excludes `NULL` owners, so the row contributes to public depth but cannot appear in `/api/v1/prediction/orders`.
 
 The confirmation event projector attaches the owner; if the confirmation event arrives first, it is deferred and replayed once the OrderBook row exists (via the existing `Deferred → Applied` reprojection mechanism). This window is exposed to clients as an eventual-consistency note in `api-spec.md`; no additional mitigation is provided in v1.
 
@@ -673,7 +673,7 @@ Returns the caller's outcome-token holdings for one market. `free` comes from a 
 
 Three inputs feed one response:
 
-1. **Market resolution.** Two SELECTs (one on [`markets`](data-schema.md#markets) INNER-joined to [`ref_tokens`](data-schema.md#ref_tokens) for the quote-asset `decimals`, one on [`market_outcomes`](data-schema.md#market_outcomes)) return `(event_id, oracle_list_hash, token_type, orderbook_address, num_outcomes, decimals, [(outcome_id, symbol, quantity_precision) …])`. The first is gated on `last_reconciled_at IS NOT NULL`; pre-reconcile markets are hidden symmetrically with `/api/v1/markets`. The `ref_tokens` join cannot hide a market: `markets.token_type` is `NOT NULL` and FK-references the statically seeded `ref_tokens` PK, so it is a strict 1:1. The market lifecycle status is NOT a gate — terminal markets still serve balances so holders can see what they own until they claim or settle. Keeping the per-outcome rows in a separate SELECT keeps the row types simple at the cost of one extra round trip.
+1. **Market resolution.** Two SELECTs (one on [`markets`](data-schema.md#prediction-markets) INNER-joined to [`ref_tokens`](data-schema.md#ref_tokens) for the quote-asset `decimals`, one on [`market_outcomes`](data-schema.md#market_outcomes)) return `(event_id, oracle_list_hash, token_type, orderbook_address, num_outcomes, decimals, [(outcome_id, symbol, quantity_precision) …])`. The first is gated on `last_reconciled_at IS NOT NULL`; pre-reconcile markets are hidden symmetrically with `/api/v1/prediction/markets`. The `ref_tokens` join cannot hide a market: `markets.token_type` is `NOT NULL` and FK-references the statically seeded `ref_tokens` PK, so it is a strict 1:1. The market lifecycle status is NOT a gate — terminal markets still serve balances so holders can see what they own until they claim or settle. Keeping the per-outcome rows in a separate SELECT keeps the row types simple at the cost of one extra round trip.
 2. **PN stake state.** The chain-side accessor is the auto-generated getter for the public mapping `PrivateNote._stakes`. TVM Solidity auto-getters for public mappings take no arguments and return the entire `map(uint256 → StakeInfo)` — see the PN ABI under `contracts/dex/PrivateNote.abi.json`. The API computes the per-market key `stake_hash = tvm.hash(abi.encode(event_id, oracle_list_hash, token_type))` — the same hash the PN itself uses internally — and looks it up on the returned map. The hash is built off-chain in Rust via a thin wrapper around `tvm_types`. Each `StakeInfo` value carries three parallel `uint128[]` arrays (`amount`, `debtAmount`, `couponsAmount`) indexed by `outcome_id`, plus housekeeping fields the API ignores. A missing key on the returned map (caller never staked on this market) is treated as "all outcomes at zero", not as an error.
 
    Returning the whole mapping in one call costs the same as one keyed lookup would on EVM (the ABI shape is fixed by TVM Solidity), so this is an opportunity, not a tax: a future "all my outcomes" view across markets needs no additional chain calls.
@@ -694,7 +694,7 @@ Three inputs feed one response:
 ### Pipeline
 
 1. `require_auth(Permission::UserData)` resolves `(account_id, pn_address)`.
-2. Parse `marketAddress` — blank or missing → `MissingParameter` → 400 / `-1102`.
+2. Parse `predictionMarketAddress` — blank or missing → `MissingParameter` → 400 / `-1102`.
 3. Run the market-resolution SELECT. Unknown market or `last_reconciled_at IS NULL` → `InvalidMarketOrSymbol` → 404 / `-1121`.
 4. Compute `stake_hash = tvm.hash(abi.encode(event_id, oracle_list_hash, token_type))`.
 5. In parallel (`tokio::try_join!` — the first error short-circuits, but a typed `DomainError` from either branch is preserved so the handler still maps it correctly):
@@ -712,7 +712,7 @@ Why `free` reads chain and `lockedInOrders` reads `live_orders`:
 - `free` comes from `PrivateNote._stakes(hash)`, which the contract mutates atomically with every stake / claim / split / merge / cancel-callback. There is no equivalent indexer projection today, and building one would require projectors for the five stake-mutation events listed in the [stake-projection follow-up](#stake-projection--future-work).
 - `lockedInOrders` is the sum of resting sell orders against this outcome. The indexer already tracks these in `live_orders`, with a partial index already sized for per-owner queries. The chain-side analogue would require iterating the OrderBook's internal red-black tree of orders — there is no public per-outcome getter for it.
 
-The split means the two numbers can drift while the indexer is replaying behind chain head: a sell that just landed on chain shows up in `_stakes.amount` (because the OB has not yet acknowledged the lock) AND in `live_orders` (because `OrderPlaced` was projected) — appearing as if both `free` and `lockedInOrders` count it. The window is small (seconds) and self-resolves once `OrderPlacedConfirmed` advances PN state; it surfaces to clients as the same eventual-consistency note that already applies to `/api/v1/orders`.
+The split means the two numbers can drift while the indexer is replaying behind chain head: a sell that just landed on chain shows up in `_stakes.amount` (because the OB has not yet acknowledged the lock) AND in `live_orders` (because `OrderPlaced` was projected) — appearing as if both `free` and `lockedInOrders` count it. The window is small (seconds) and self-resolves once `OrderPlacedConfirmed` advances PN state; it surfaces to clients as the same eventual-consistency note that already applies to `/api/v1/prediction/orders`.
 
 ### Fail-closed validation
 
@@ -720,7 +720,7 @@ Three fail-closed checks guard the pipeline at different stages:
 
 | Rule | Source |
 | --- | --- |
-| Resolved market has a non-blank `orderbook_address` | DB schema CHECK (`last_reconciled_at IS NULL OR orderbook_address IS NOT NULL`) plus a whitespace re-check, matching `/api/v1/depth`'s contract |
+| Resolved market has a non-blank `orderbook_address` | DB schema CHECK (`last_reconciled_at IS NULL OR orderbook_address IS NOT NULL`) plus a whitespace re-check, matching `/api/v1/prediction/depth`'s contract |
 | `_stakes.amount.len() == num_outcomes` (and same for `debtAmount`, `couponsAmount`) when any array is non-empty | The contract initializes all three arrays to `num_outcomes` length on first stake; a mismatch means the indexer's view of `num_outcomes` diverged from chain state |
 | Every `live_orders.outcome_id` returned by the aggregation is within `[0, num_outcomes)` | Sanity: a row outside this range is indexer corruption (`OrderBook.OrderPlaced` projector wrote an unknown `outcome_id`) |
 
@@ -728,7 +728,7 @@ Violations surface as `MarketInconsistent` → 503.
 
 ### Eventual consistency
 
-`lockedInOrders` inherits the same indexer-backlog window as `/api/v1/orders`: a sell order whose `OrderBook.OrderPlaced` event has not been projected yet is invisible here. Once projected (typically seconds later), the next response shows it. `free` is read live from chain state and does not inherit this window.
+`lockedInOrders` inherits the same indexer-backlog window as `/api/v1/prediction/orders`: a sell order whose `OrderBook.OrderPlaced` event has not been projected yet is invisible here. Once projected (typically seconds later), the next response shows it. `free` is read live from chain state and does not inherit this window.
 
 ### Error mapping
 
@@ -736,8 +736,8 @@ Violations surface as `MarketInconsistent` → 503.
 | --- | --- | --- | --- |
 | Missing / invalid auth envelope | upstream | `-1003` | 401 |
 | Unknown / disabled key, or key lacks `USER_DATA` | upstream | `-1002` | 401 |
-| `marketAddress` missing or blank | `MissingParameter` | `-1102` | 400 |
-| `marketAddress` not found, or its market is unreconciled | `InvalidMarketOrSymbol` | `-1121` | 404 |
+| `predictionMarketAddress` missing or blank | `MissingParameter` | `-1102` | 400 |
+| `predictionMarketAddress` not found, or its market is unreconciled | `InvalidMarketOrSymbol` | `-1121` | 404 |
 | Authenticated PN address has no deployed contract on chain | `AccountNotDeployed` | `-2013` | 404 |
 | Chain getter / BOC fetch / decode failure, or invariant violation on assembled DTO | `MarketInconsistent` | `-1500` | 503 |
 | Request budget elapsed | `RequestTimeout` | `-1007` | 504 |
@@ -764,4 +764,4 @@ Four test suites, all gated on `TEST_DATABASE_URL`:
   - `get_market_balances_use_case_tests`: happy path sums the three stake pools per outcome; absent stake key yields zero free; stake arrays shorter / longer than `num_outcomes`; mixed empty / populated stake arrays; unknown market; PN failure; hasher failure; out-of-range `outcome_id`.
 - Repo integration (`crates/infrastructure/tests/balances.rs`): `lookup_ref_token` happy path; `resolve_market_for_balances` happy path / unknown market / unreconciled market / num_outcomes mismatch; the three fail-closed guards (NULL `oracle_list_hash`, blank `orderbook_address`, negative `token_type`); `sum_open_sell_remaining` groups by outcome and filters; empty when no rows match.
 - HTTP integration (`services/api/tests/account_http.rs`): happy path; missing API key → 401 / `-1003`; chain-getter failure → 503 / `-1500`; unknown token type → 503 / `-1500`; two credentials produce distinct `accountId`.
-- HTTP integration (`services/api/tests/account_balances_http.rs`): happy path sorted by `outcomeId`; absent stake key yields zero free with nonzero locked; missing `marketAddress` → 400 / `-1102`; unknown market → 404 / `-1121`; stake-array mismatch → 503 / `-1500`; terminal market still serves; stake gateway failure → 503 / `-1500`; missing API key → 401 / `-1003`; cross-tenant isolation; production hasher wiring; stake registered at wrong hash yields zero; trade-only key → `-1002` on the user-data route.
+- HTTP integration (`services/api/tests/account_balances_http.rs`): happy path sorted by `outcomeId`; absent stake key yields zero free with nonzero locked; missing `predictionMarketAddress` → 400 / `-1102`; unknown market → 404 / `-1121`; stake-array mismatch → 503 / `-1500`; terminal market still serves; stake gateway failure → 503 / `-1500`; missing API key → 401 / `-1003`; cross-tenant isolation; production hasher wiring; stake registered at wrong hash yields zero; trade-only key → `-1002` on the user-data route.

--- a/docs/tech-specs/write-api.md
+++ b/docs/tech-specs/write-api.md
@@ -4,12 +4,12 @@ Implementation-facing requirements for the write endpoints (trading, position, a
 
 | Endpoint | Method | api-spec section |
 | --- | --- | --- |
-| `/api/v1/order` | POST | [New Order](../api-spec.md#new-order) |
-| `/api/v1/order` | DELETE | [Cancel Order](../api-spec.md#cancel-order) |
-| `/api/v1/batchOrders` | POST | [New Batch Orders](../api-spec.md#new-batch-orders) |
-| `/api/v1/batchOrders` | DELETE | [Cancel Batch Orders](../api-spec.md#cancel-batch-orders) |
-| `/api/v1/openOrders` | DELETE | [Cancel All Open Orders On Symbol](../api-spec.md#cancel-all-open-orders-on-symbol) |
-| `/api/v1/buyFullSet` | POST | [Buy Full Set](../api-spec.md#buy-full-set) |
+| `/api/v1/prediction/order` | POST | [New Order](../api-spec.md#new-order) |
+| `/api/v1/prediction/order` | DELETE | [Cancel Order](../api-spec.md#cancel-order) |
+| `/api/v1/prediction/batchOrders` | POST | [New Batch Orders](../api-spec.md#new-batch-orders) |
+| `/api/v1/prediction/batchOrders` | DELETE | [Cancel Batch Orders](../api-spec.md#cancel-batch-orders) |
+| `/api/v1/prediction/openOrders` | DELETE | [Cancel All Open Orders On Symbol](../api-spec.md#cancel-all-open-orders-on-symbol) |
+| `/api/v1/prediction/buyFullSet` | POST | [Buy Full Set](../api-spec.md#buy-full-set) |
 | `/api/v1/accounts` | POST | [Register Account](../api-spec.md#register-account) |
 
 ## Glossary
@@ -18,13 +18,13 @@ Implementation-facing requirements for the write endpoints (trading, position, a
 
 **Chain sender** — the backend component that signs an external message under the trading-PN seckey and dispatches it to the Acki Nacki gateway. Defined as a `ChainOrderSender` trait in `crates/application`; the production implementation in `crates/infrastructure` wraps the `PrivateNote` ABI bindings exposed by `ackinacki-kit/contracts/src/dex/private_note.rs`.
 
-**Optimistic submission** — `POST /api/v1/order` returns once the chain sender has acknowledged dispatch of the external message, before any on-chain confirmation. The chain-assigned `orderId` is not available at response time — it appears later when the indexer projects `OrderBook.OrderPlaced` into [`live_orders`](data-schema.md#live_orders). Clients learn the `orderId` by polling `GET /api/v1/orders` and matching on the `clientOrderId` they supplied or received.
+**Optimistic submission** — `POST /api/v1/prediction/order` returns once the chain sender has acknowledged dispatch of the external message, before any on-chain confirmation. The chain-assigned `orderId` is not available at response time — it appears later when the indexer projects `OrderBook.OrderPlaced` into [`live_orders`](data-schema.md#live_orders). Clients learn the `orderId` by polling `GET /api/v1/prediction/orders` and matching on the `clientOrderId` they supplied or received.
 
 **clientOrderId** — caller-supplied (request field `newOrderClientId`) or backend-generated identifier that correlates the response with the eventually-projected `live_orders` row. Carried by the chain as `uint128` and surfaced in every `OrderBook` event (see [dex-events-routing.md](../contract-specs/dex-events-routing.md#orderbook)). The chain enforces per-PN uniqueness across still-live coids; collisions are silently rejected (`Rejected` event, no `OrderPlaced`).
 
 **PN busy window** — between `PrivateNote.placeOrder` and the matching `onOrderPlaced` callback, the PN's `_busy` flag is set and any further `placeOrder` is rejected on-chain with `ERR_NOTE_BUSY` (`contracts/dex/PrivateNote.sol:1178`). Each account has exactly one trading PN, so placement against one account is serial at the chain level.
 
-## `POST /api/v1/order`
+## `POST /api/v1/prediction/order`
 
 The handler runs three phases: request parsing → market/outcome resolution and input validation → chain submission. Each phase fails closed with its own error code (see [Error mapping](#error-mapping)); a later phase only runs once the earlier one has produced a fully-typed value.
 
@@ -40,7 +40,7 @@ Body fields are taken byte-exact from the request as transmitted; the HMAC layer
 
 | Field | Type | Notes |
 | --- | --- | --- |
-| `marketAddress` | `MarketAddress` | Mandatory. |
+| `predictionMarketAddress` | `MarketAddress` | Mandatory. |
 | `symbol` | `Symbol` | Mandatory. |
 | `newOrderClientId` | `Option<String>` | Optional; absent → backend generates (see [clientOrderId](#clientorderid-generation)). |
 | `side` | `OrderSide` | Mandatory; `BUY` or `SELL`. |
@@ -51,7 +51,7 @@ Body fields are taken byte-exact from the request as transmitted; the HMAC layer
 
 ### Market and outcome resolution
 
-Resolve `(marketAddress, symbol)` to a single row via [`markets`](data-schema.md#markets) ⨝ [`market_outcomes`](data-schema.md#market_outcomes), filtered by `m.last_reconciled_at IS NOT NULL` — the same visibility gate as [`/api/v1/markets`](read-api.md#visibility-filter). A miss surfaces as `InvalidMarketOrSymbol` → 404.
+Resolve `(predictionMarketAddress, symbol)` to a single row via [`markets`](data-schema.md#prediction-markets) ⨝ [`market_outcomes`](data-schema.md#market_outcomes), filtered by `m.last_reconciled_at IS NOT NULL` — the same visibility gate as [`/api/v1/prediction/markets`](read-api.md#visibility-filter). A miss surfaces as `InvalidMarketOrSymbol` → 404.
 
 Derive `status` from the row and request `now` using the logic in [read-api.md §Status derivation](read-api.md#status-derivation). Placement is permitted only when `status == TRADING`; any other phase rejects with `OrderValidationFailed` → 400 (-2010). The status derivation and the precision/step columns come from the same SELECT, so a status flip between read and validate is not possible inside one request.
 
@@ -70,11 +70,11 @@ The same row supplies every value the chain submission requires:
 
 ### Input validation
 
-Each [api-spec §Validation Rules](../api-spec.md#validation-rules) row maps to one check. Inputs are exact-decimal at this point; comparisons use `num-bigint::BigUint` lifted by `price_precision` / `quantity_precision`, the inverse of the lifting `/api/v1/depth` uses to render levels ([read-api.md §Aggregation](read-api.md#aggregation)). Lexicographic string comparison would silently misrank `"100"` vs `"99"`.
+Each [api-spec §Validation Rules](../api-spec.md#validation-rules) row maps to one check. Inputs are exact-decimal at this point; comparisons use `num-bigint::BigUint` lifted by `price_precision` / `quantity_precision`, the inverse of the lifting `/api/v1/prediction/depth` uses to render levels ([read-api.md §Aggregation](read-api.md#aggregation)). Lexicographic string comparison would silently misrank `"100"` vs `"99"`.
 
 | api-spec rule | Failure |
 | --- | --- |
-| `marketAddress` / `symbol` resolve | `InvalidMarketOrSymbol` |
+| `predictionMarketAddress` / `symbol` resolve | `InvalidMarketOrSymbol` |
 | Market `status == TRADING` | `OrderValidationFailed` |
 | Valid `type` × `timeInForce` combination (see [Flags](#flags)) | `InvalidParameter` |
 | `price` decimals ≤ `pricePrecision` (LIMIT) | `PrecisionExceeded` |
@@ -87,7 +87,7 @@ Each [api-spec §Validation Rules](../api-spec.md#validation-rules) row maps to 
 
 The local checks duplicate the contract's own validation (`contracts/dex/PrivateNote.sol:1179-1197`) and exist to surface a fast `-1111` / `-2010` to a misbehaving client without spending a chain round-trip on a doomed submission. The chain remains the authority.
 
-Balance is not pre-checked. The chain enforces sufficiency on-chain (`ERR_LOW_VALUE` at `contracts/dex/PrivateNote.sol:1219`); clients track their own available balance via `GET /api/v1/account`. The chain rejection itself surfaces synchronously through [Failure surface](#failure-surface) §2 — `BeeDexChainSender` waits for the `PrivateNote.placeOrder` execution, so an insufficient-balance reject becomes `OrderValidationFailed` → 400 / -2010 on the HTTP response rather than silent absence in `/api/v1/orders`.
+Balance is not pre-checked. The chain enforces sufficiency on-chain (`ERR_LOW_VALUE` at `contracts/dex/PrivateNote.sol:1219`); clients track their own available balance via `GET /api/v1/account`. The chain rejection itself surfaces synchronously through [Failure surface](#failure-surface) §2 — `BeeDexChainSender` waits for the `PrivateNote.placeOrder` execution, so an insufficient-balance reject becomes `OrderValidationFailed` → 400 / -2010 on the HTTP response rather than silent absence in `/api/v1/prediction/orders`.
 
 ### Flags
 
@@ -175,11 +175,11 @@ A successful submission returns a deliberately minimal three-field body:
 | `transactTime` | `now_pair()` captured once at the start of the handler. |
 | `status` | Always `"PENDING_NEW"` — the order has been accepted by `PrivateNote.placeOrder` (chain return of `bee_dex::Dex::place_order` succeeded) but is **not yet on the book**; `OrderBook.executeBatch` is processing the internal message and will emit `OrderPlaced` with the chain-assigned `orderId` shortly after. |
 
-Why minimal: every other field a fully-populated order would carry (`marketAddress`, `symbol`, `side`, `type`, `timeInForce`, `price`, `origQty`) is **already in the request the client just sent** — echoing them adds bytes without adding information. Two specific fields the Binance-style shape carries (`orderId`, `executedQty`) cannot be filled honestly under optimistic submission: `orderId` is assigned by `OrderBook` after our return, and `executedQty` is always zero for a freshly-placed order. Surfacing them as `""` / `"0"` is worse than not surfacing them — it implies the order is further along the lifecycle than it actually is.
+Why minimal: every other field a fully-populated order would carry (`predictionMarketAddress`, `symbol`, `side`, `type`, `timeInForce`, `price`, `origQty`) is **already in the request the client just sent** — echoing them adds bytes without adding information. Two specific fields the Binance-style shape carries (`orderId`, `executedQty`) cannot be filled honestly under optimistic submission: `orderId` is assigned by `OrderBook` after our return, and `executedQty` is always zero for a freshly-placed order. Surfacing them as `""` / `"0"` is worse than not surfacing them — it implies the order is further along the lifecycle than it actually is.
 
-The client correlates the response with future `live_orders` rows by polling `GET /api/v1/orders` and matching by `clientOrderId` in the returned `orders[]`. The `PENDING_NEW` status flips to `NEW` once the indexer projects `OrderPlaced`.
+The client correlates the response with future `live_orders` rows by polling `GET /api/v1/prediction/orders` and matching by `clientOrderId` in the returned `orders[]`. The `PENDING_NEW` status flips to `NEW` once the indexer projects `OrderPlaced`.
 
-`PENDING_NEW` is listed in [api-spec §Order Status](../api-spec.md#order-status); it's the only status `POST /api/v1/order` returns on success. Strictly additive — code that only switches on `NEW`/`PARTIALLY_FILLED`/`FILLED`/`CANCELED`/`REJECTED` continues to work because those values still arrive through `/api/v1/orders`.
+`PENDING_NEW` is listed in [api-spec §Order Status](../api-spec.md#order-status); it's the only status `POST /api/v1/prediction/order` returns on success. Strictly additive — code that only switches on `NEW`/`PARTIALLY_FILLED`/`FILLED`/`CANCELED`/`REJECTED` continues to work because those values still arrive through `/api/v1/prediction/orders`.
 
 
 ### Failure surface
@@ -203,9 +203,9 @@ Three failure classes — two synchronous, one async:
 
    The MM client therefore knows immediately why a given `POST` failed for the common cases and does not have to detect rejection through polling absence.
 
-3. **OrderBook chain-side, surfaced asynchronously** — once `PrivateNote.placeOrder` accepts, it sends an internal message to `OrderBook.executeBatch`. That executes in a separate transaction the synchronous return cannot observe. If `OrderBook` then rejects (`OrderBook.Rejected` for coid collision against a still-live coid, queue overflow, or ABI-level validation), the indexer records the raw event but does not (today) insert a row into `live_orders`. From the HTTP caller's standpoint the `POST` returned `200 NEW`, but the order never surfaces in `/api/v1/orders` until the REJECTED follow-up ships ([read-api.md §REJECTED — future work](read-api.md#rejected--future-work)). Clients detect this class by absence: a `clientOrderId` that does not appear within a few seconds was OrderBook-rejected. This residual asynchronicity is the only case left where MM bots must implement absence-detection — typical rejections (balance, busy, validation) now surface synchronously through class 2.
+3. **OrderBook chain-side, surfaced asynchronously** — once `PrivateNote.placeOrder` accepts, it sends an internal message to `OrderBook.executeBatch`. That executes in a separate transaction the synchronous return cannot observe. If `OrderBook` then rejects (`OrderBook.Rejected` for coid collision against a still-live coid, queue overflow, or ABI-level validation), the indexer records the raw event but does not (today) insert a row into `live_orders`. From the HTTP caller's standpoint the `POST` returned `200 NEW`, but the order never surfaces in `/api/v1/prediction/orders` until the REJECTED follow-up ships ([read-api.md §REJECTED — future work](read-api.md#rejected--future-work)). Clients detect this class by absence: a `clientOrderId` that does not appear within a few seconds was OrderBook-rejected. This residual asynchronicity is the only case left where MM bots must implement absence-detection — typical rejections (balance, busy, validation) now surface synchronously through class 2.
 
-Transport-level failures (gateway connection drop, malformed reply, decode error) sit outside this classification and always collapse to `Unexpected` → 500 / -1000 with the raw `AppError` logged at `error` level. Accepted orders that later get filled or cancelled by normal market activity are not failures and are surfaced through `/api/v1/orders` per [read-api.md](read-api.md).
+Transport-level failures (gateway connection drop, malformed reply, decode error) sit outside this classification and always collapse to `Unexpected` → 500 / -1000 with the raw `AppError` logged at `error` level. Accepted orders that later get filled or cancelled by normal market activity are not failures and are surfaced through `/api/v1/prediction/orders` per [read-api.md](read-api.md).
 
 **`-2014 OrderPnBusy` is transitional.** The current account model has exactly one trading PN per account ([auth.md §Trading Private Note](auth.md#trading-private-note)). When multi-PN trading lands (one account routing orders across several PNs in parallel), `_busy` ceases to be a per-account bottleneck and a client hitting `ERR_NOTE_BUSY` would mean an internal PN-selection bug — at that point this row collapses back into `OrderValidationFailed` / 400 and the `-2014` code is removed from the public surface. SDK authors should treat `-2014` the same as `-2010` plus a short retry hint; do not bake persistent retry logic keyed on this specific code.
 
@@ -242,15 +242,15 @@ The use case constructor takes trait objects, never concrete types, so the test-
 
 ### Idempotency and retries
 
-The backend does not store inflight submissions and does not retry on its own. Clients that need at-least-once delivery supply a fixed `newOrderClientId` and re-`POST` on transient errors: the chain rejects the second submission with the same coid (silent `Rejected`), and `/api/v1/orders` keyed on `clientOrderId` surfaces the eventually-confirmed state of the first one.
+The backend does not store inflight submissions and does not retry on its own. Clients that need at-least-once delivery supply a fixed `newOrderClientId` and re-`POST` on transient errors: the chain rejects the second submission with the same coid (silent `Rejected`), and `/api/v1/prediction/orders` keyed on `clientOrderId` surfaces the eventually-confirmed state of the first one.
 
 ### Concurrency
 
-Placement against one trading PN is serial at the chain ([PN busy window](#glossary)). The API does not coordinate concurrent submissions across replicas — two `POST /api/v1/order` requests from the same account that land on different API instances are sent to the chain in whatever order the gateway receives them. The losing submission is rejected on-chain with `ERR_NOTE_BUSY`; `BeeDexChainSender` maps that synchronously to `OrderPnBusy` → 429 / -2014 (see [Failure surface](#failure-surface) §2), so the client receives an actionable retry signal on the HTTP response rather than having to detect absence in `/api/v1/orders`.
+Placement against one trading PN is serial at the chain ([PN busy window](#glossary)). The API does not coordinate concurrent submissions across replicas — two `POST /api/v1/prediction/order` requests from the same account that land on different API instances are sent to the chain in whatever order the gateway receives them. The losing submission is rejected on-chain with `ERR_NOTE_BUSY`; `BeeDexChainSender` maps that synchronously to `OrderPnBusy` → 429 / -2014 (see [Failure surface](#failure-surface) §2), so the client receives an actionable retry signal on the HTTP response rather than having to detect absence in `/api/v1/prediction/orders`.
 
-Clients that need higher per-account throughput batch multiple orders into one chain message via `POST /api/v1/batchOrders` — one `placeBatch` call covers many orders under a single `_busy` lock.
+Clients that need higher per-account throughput batch multiple orders into one chain message via `POST /api/v1/prediction/batchOrders` — one `placeBatch` call covers many orders under a single `_busy` lock.
 
-## `DELETE /api/v1/order`
+## `DELETE /api/v1/prediction/order`
 
 The handler runs three phases: request parsing → order resolution (which folds market lookup, status derivation, and ownership into one SELECT) → chain submission. Each phase fails closed with its own error code (see [DELETE error mapping](#error-mapping-1)). The on-chain cancel itself is optimistic in the same sense as POST: `PrivateNote.cancelOrder` returns once PN has forwarded the cancel to `OrderBook.executeBatch` as an internal message — the actual removal from the book and the projection into [`live_orders`](data-schema.md#live_orders) happen asynchronously through the indexer.
 
@@ -264,7 +264,7 @@ DELETE has no body; all named parameters arrive in the query string (the HMAC la
 
 | Field | Type | Notes |
 | --- | --- | --- |
-| `marketAddress` | `MarketAddress` | Mandatory. |
+| `predictionMarketAddress` | `MarketAddress` | Mandatory. |
 | `symbol` | `Symbol` | Mandatory. |
 | `orderId` | `String` | Mandatory; parsed as `u64::from_str` in the use case. The on-chain ABI is `uint128`, but the `bee_dex` → `ackinacki-kit` → `serde_json::json!` path rejects values above `u64::MAX` (same `arbitrary_precision` constraint documented in [§clientOrderId generation](#clientorderid-generation)). Out-of-range or non-numeric → `InvalidParameter` → 400 / -1130. |
 
@@ -272,15 +272,15 @@ Mandatory-field absence returns `MissingParameter` → 400.
 
 ### Order resolution
 
-One SELECT joins [`live_orders`](data-schema.md#live_orders) ⨝ [`markets`](data-schema.md#markets) ⨝ [`market_outcomes`](data-schema.md#market_outcomes) and applies five predicates at once:
+One SELECT joins [`live_orders`](data-schema.md#live_orders) ⨝ [`markets`](data-schema.md#prediction-markets) ⨝ [`market_outcomes`](data-schema.md#market_outcomes) and applies five predicates at once:
 
 - `markets.last_reconciled_at IS NOT NULL` — same visibility gate as POST.
-- `markets.pmp_address = :marketAddress` AND `market_outcomes.symbol = :symbol`. The `pmp_address` column is the SQL spelling of the public `marketAddress` field; the alias dates from the contract-level naming.
+- `markets.pmp_address = :predictionMarketAddress` AND `market_outcomes.symbol = :symbol`. The `pmp_address` column is the SQL spelling of the public `predictionMarketAddress` field; the alias dates from the contract-level naming.
 - `live_orders.order_id = :orderId` AND `live_orders.status = 'OPEN'`.
 - `live_orders.owner_pn_address = :pn_address` — pins the caller as the owner of the row.
-- `live_orders.amount_remaining > 0` — same belt-and-suspenders predicate the `/api/v1/orders` read path applies to OPEN rows. A row could in principle linger as `status = 'OPEN'` with `amount_remaining = 0` in the brief window before `apply_order_filled` flips it to `FILLED`; the gate keeps that transient slice invisible to cancel.
+- `live_orders.amount_remaining > 0` — same belt-and-suspenders predicate the `/api/v1/prediction/orders` read path applies to OPEN rows. A row could in principle linger as `status = 'OPEN'` with `amount_remaining = 0` in the brief window before `apply_order_filled` flips it to `FILLED`; the gate keeps that transient slice invisible to cancel.
 
-A miss surfaces as `UnknownOrder` → 404 / -2011 with **no distinction** between "order does not exist", "order exists but belongs to another account", "order is not OPEN anymore", or "marketAddress/symbol does not match the order's actual market". This is deliberate: differentiating those cases would leak the existence (and account binding) of orders the caller does not own.
+A miss surfaces as `UnknownOrder` → 404 / -2011 with **no distinction** between "order does not exist", "order exists but belongs to another account", "order is not OPEN anymore", or "predictionMarketAddress/symbol does not match the order's actual market". This is deliberate: differentiating those cases would leak the existence (and account binding) of orders the caller does not own.
 
 The same row supplies every value the chain submission and the response need:
 
@@ -322,9 +322,9 @@ A successful submission returns the four-field body from [api-spec §Cancel Orde
 | `transactTime` | `now_pair()` captured once at the start of the handler. |
 | `status` | Always `"PENDING_CANCEL"` — `PrivateNote.cancelOrder` has accepted the request and forwarded to OrderBook, but the order has **not been removed from the book yet**. `OrderBook` will emit `OrderCancelled` once it dequeues the entry, and the indexer will flip [`live_orders.status`](data-schema.md#live_orders) to `CANCELLED` then. |
 
-The client correlates by `orderId` against `/api/v1/orders` (the stored status flips to `CANCELED`, or to `FILLED` if matching raced the cancel).
+The client correlates by `orderId` against `/api/v1/prediction/orders` (the stored status flips to `CANCELED`, or to `FILLED` if matching raced the cancel).
 
-`PENDING_CANCEL` is listed in [api-spec §Order Status](../api-spec.md#order-status); it is the only status `DELETE /api/v1/order` returns on success. Strictly additive — `NEW`/`PARTIALLY_FILLED`/`FILLED`/`CANCELED`/`REJECTED` still arrive through `/api/v1/orders` and existing client switches keep working.
+`PENDING_CANCEL` is listed in [api-spec §Order Status](../api-spec.md#order-status); it is the only status `DELETE /api/v1/prediction/order` returns on success. Strictly additive — `NEW`/`PARTIALLY_FILLED`/`FILLED`/`CANCELED`/`REJECTED` still arrive through `/api/v1/prediction/orders` and existing client switches keep working.
 
 ### Failure surface
 
@@ -344,7 +344,7 @@ Three failure classes — two synchronous, one async — same shape as POST.
    - **Owner mismatch** — `_doCancel` silently no-ops if `o.depositHash` does not match the caller's. The pre-submit ownership lookup makes this case unreachable under normal operation; it remains possible only under read-model corruption.
    - **Queue overflow** — `OrderBook.Rejected` fires; the indexer records the raw event but does not touch `live_orders`. The order stays `OPEN`.
 
-   An HTTP 200 `PENDING_CANCEL` is therefore not a guarantee that the cancel will land — it confirms only that `PrivateNote.cancelOrder` accepted the request. `PENDING_CANCEL` is the DELETE response token only; it is never persisted to `live_orders.status`, so polling `/api/v1/orders` continues to report `NEW` / `PARTIALLY_FILLED` until the indexer applies `OrderCancelled` or `OrderFilled` and flips the stored status to `CANCELED` or `FILLED`. Clients detect class-3 outcomes by watching for that flip on the `orderId` within a reasonable window.
+   An HTTP 200 `PENDING_CANCEL` is therefore not a guarantee that the cancel will land — it confirms only that `PrivateNote.cancelOrder` accepted the request. `PENDING_CANCEL` is the DELETE response token only; it is never persisted to `live_orders.status`, so polling `/api/v1/prediction/orders` continues to report `NEW` / `PARTIALLY_FILLED` until the indexer applies `OrderCancelled` or `OrderFilled` and flips the stored status to `CANCELED` or `FILLED`. Clients detect class-3 outcomes by watching for that flip on the `orderId` within a reasonable window.
 
 Transport-level failures (gateway drop, decode error) collapse to `Unexpected` → 500 / -1000 with the raw `AppError` logged at `error`, same as POST.
 
@@ -357,7 +357,7 @@ Transport-level failures (gateway drop, decode error) collapse to `Unexpected` �
 | Mandatory query field missing | `MissingParameter` | 400 |
 | `orderId` not numeric or overflows u64 | `InvalidParameter` | 400 |
 | Reconciled market with NULL `oracle_list_hash` | `MarketInconsistent` | 503 |
-| `(marketAddress, symbol, orderId)` does not resolve to an OPEN order owned by the caller (covers unknown order, wrong owner, wrong market, already closed) | `UnknownOrder` | 404 |
+| `(predictionMarketAddress, symbol, orderId)` does not resolve to an OPEN order owned by the caller (covers unknown order, wrong owner, wrong market, already closed) | `UnknownOrder` | 404 |
 | Resolved market `status != TRADING` | `OrderValidationFailed` | 400 |
 | Chain `ERR_NOTE_BUSY` (per-PN serial; another op still in flight) | `OrderPnBusy` | 429 |
 | Handler exceeded `ServerSection.request_timeout_ms` | `RequestTimeout` | 504 |
@@ -388,13 +388,13 @@ The backend stores no inflight cancel state and does not retry on its own. Dupli
 
 Cancellation contends for the same per-PN `_busy` lock as placement — see [§Concurrency for POST /order](#concurrency). A DELETE that races a POST (or another DELETE) from the same account surfaces as `OrderPnBusy` → 429 / -2014 with the same retry semantics.
 
-## `POST /api/v1/batchOrders`
+## `POST /api/v1/prediction/batchOrders`
 
-The handler runs three phases: request parsing → market/outcome resolution and per-item input validation → chain submission. Layout mirrors `POST /api/v1/order`: the per-item validation chain is the same and lives in one shared helper. Each phase fails closed with its own error code (see [Batch error mapping](#error-mapping-2)).
+The handler runs three phases: request parsing → market/outcome resolution and per-item input validation → chain submission. Layout mirrors `POST /api/v1/prediction/order`: the per-item validation chain is the same and lives in one shared helper. Each phase fails closed with its own error code (see [Batch error mapping](#error-mapping-2)).
 
 ### Authorization
 
-Same hoop as `POST /api/v1/order`. The handler calls `require_auth(depot, Permission::Trade)` and reads the resolved [`TradingPn`](auth.md#trading-private-note) out of `AuthContext`. All items in the batch are signed by the same trading-PN keypair — the chain ABI accepts only one external message and the busy lock is per-PN regardless of batch size.
+Same hoop as `POST /api/v1/prediction/order`. The handler calls `require_auth(depot, Permission::Trade)` and reads the resolved [`TradingPn`](auth.md#trading-private-note) out of `AuthContext`. All items in the batch are signed by the same trading-PN keypair — the chain ABI accepts only one external message and the busy lock is per-PN regardless of batch size.
 
 ### Request parsing
 
@@ -404,15 +404,15 @@ Top-level body fields:
 
 | Field | Type | Notes |
 | --- | --- | --- |
-| `marketAddress` | `MarketAddress` | Mandatory. |
+| `predictionMarketAddress` | `MarketAddress` | Mandatory. |
 | `symbol` | `Symbol` | Mandatory. |
-| `orders` | `Vec<BatchOrderInputItem>` | Mandatory and non-empty. Maximum length equals the configured `chain.max_batch_size` (advertised as `maxBatchSize` in `/api/v1/markets`). |
+| `orders` | `Vec<BatchOrderInputItem>` | Mandatory and non-empty. Maximum length equals the configured `chain.max_batch_size` (advertised as `maxBatchSize` in `/api/v1/prediction/markets`). |
 
-Each `BatchOrderInputItem` is shaped the same as the body of `POST /api/v1/order` minus `marketAddress` / `symbol` (the chain ABI takes those once per batch, not per item). An unknown enum value (`side`, `type`, `timeInForce`) on any item returns `InvalidParameter` → 400.
+Each `BatchOrderInputItem` is shaped the same as the body of `POST /api/v1/prediction/order` minus `predictionMarketAddress` / `symbol` (the chain ABI takes those once per batch, not per item). An unknown enum value (`side`, `type`, `timeInForce`) on any item returns `InvalidParameter` → 400.
 
 ### Market and outcome resolution
 
-`(marketAddress, symbol)` is resolved once via the same `resolve_for_new_order` join `POST /api/v1/order` uses, including the visibility gate (`m.last_reconciled_at IS NOT NULL`) and the [Status derivation](read-api.md#status-derivation) clause. A miss surfaces as `InvalidMarketOrSymbol` → 404. Placement is permitted only when `status == TRADING`; any other phase rejects with `OrderValidationFailed` → 400. A reconciled market with NULL/blank `oracle_list_hash` surfaces as `MarketInconsistent` → 503 — same fail-closed invariant as POST.
+`(predictionMarketAddress, symbol)` is resolved once via the same `resolve_for_new_order` join `POST /api/v1/prediction/order` uses, including the visibility gate (`m.last_reconciled_at IS NOT NULL`) and the [Status derivation](read-api.md#status-derivation) clause. A miss surfaces as `InvalidMarketOrSymbol` → 404. Placement is permitted only when `status == TRADING`; any other phase rejects with `OrderValidationFailed` → 400. A reconciled market with NULL/blank `oracle_list_hash` surfaces as `MarketInconsistent` → 503 — same fail-closed invariant as POST.
 
 The resolved row supplies the chain-level fields once for the whole batch:
 
@@ -428,17 +428,17 @@ The resolved row supplies the chain-level fields once for the whole batch:
 
 ### Batch size cap
 
-The cap is the api config knob `chain.max_batch_size` — the same value `/api/v1/markets` advertises as `maxBatchSize`, so the promise and the enforcement share one source. It manually mirrors the chain's compiled-in per-side `MAX_BATCH_SIZE` (`contracts/dex/modifiers/modifiers.sol`, 10 today; the chain exposes no getter for it) and must not exceed it. An empty `orders[]` or one whose length exceeds the cap surfaces as `InvalidParameter` → 400 / -1130 before the chain submission.
+The cap is the api config knob `chain.max_batch_size` — the same value `/api/v1/prediction/markets` advertises as `maxBatchSize`, so the promise and the enforcement share one source. It manually mirrors the chain's compiled-in per-side `MAX_BATCH_SIZE` (`contracts/dex/modifiers/modifiers.sol`, 10 today; the chain exposes no getter for it) and must not exceed it. An empty `orders[]` or one whose length exceeds the cap surfaces as `InvalidParameter` → 400 / -1130 before the chain submission.
 
 ### Per-item input validation
 
-Per-item validation is identical to `POST /api/v1/order` — same precision / tick / step / notional / coid rules from [api-spec §Validation Rules](../api-spec.md#validation-rules). The shared helper `validate_and_encode_order_item` in `crates/application/src/lib.rs` runs the chain for both endpoints, so a future tightening (e.g. tighter step-size handling) touches one place. The helper also encodes the chain-shaped fields (`outcome_id`, `is_buy`, `price_raw`, `amount_raw`, `flags`, `client_order_id`) the dispatch needs.
+Per-item validation is identical to `POST /api/v1/prediction/order` — same precision / tick / step / notional / coid rules from [api-spec §Validation Rules](../api-spec.md#validation-rules). The shared helper `validate_and_encode_order_item` in `crates/application/src/lib.rs` runs the chain for both endpoints, so a future tightening (e.g. tighter step-size handling) touches one place. The helper also encodes the chain-shaped fields (`outcome_id`, `is_buy`, `price_raw`, `amount_raw`, `flags`, `client_order_id`) the dispatch needs.
 
 The loop short-circuits on the first item-level failure: the entire request rejects with the failing item's error code; no chain message is sent. This matches the chain's atomic `placeBatch` semantics — partial submission is not a possible outcome — and avoids spending the per-PN busy window on a doomed batch. The response carries one error object regardless of how many items would have failed; the client correlates by re-reading its own request payload.
 
 ### Flags
 
-Same encoding table as `POST /api/v1/order` — see [Flags](#flags). The chain's `OrderBookOrder.flags` field is per-item, so a single batch can mix LIMIT and MARKET orders freely as long as each item's combination is valid.
+Same encoding table as `POST /api/v1/prediction/order` — see [Flags](#flags). The chain's `OrderBookOrder.flags` field is per-item, so a single batch can mix LIMIT and MARKET orders freely as long as each item's combination is valid.
 
 ### `clientOrderId` generation
 
@@ -460,7 +460,7 @@ placeBatch(
 )
 ```
 
-Per-item `minAmount` and `epochId` stay at 0 — same constants as `placeOrder` (neither is exposed by api-spec and neither has a per-order meaning in this version of the public API). `cancelIds` is the cancellation side of the chain's atomic batch — `placeBatch` is the single batch entry point and processes both sides in one `OrderBook.executeBatch` dispatch. `POST /api/v1/batchOrders` is placement-only and always sends `cancelIds = []`; the populated side belongs to `DELETE /api/v1/batchOrders`.
+Per-item `minAmount` and `epochId` stay at 0 — same constants as `placeOrder` (neither is exposed by api-spec and neither has a per-order meaning in this version of the public API). `cancelIds` is the cancellation side of the chain's atomic batch — `placeBatch` is the single batch entry point and processes both sides in one `OrderBook.executeBatch` dispatch. `POST /api/v1/prediction/batchOrders` is placement-only and always sends `cancelIds = []`; the populated side belongs to `DELETE /api/v1/prediction/batchOrders`.
 
 Sender boundary: the existing `ChainOrderSender` trait grows a third method `async fn submit_batch_order(&self, payload: NewBatchOrderPayload) -> Result<(), DomainError>`. The production `BeeDexChainSender` impl wraps `bee_dex::Dex::place_batch`, reuses `build_signer` for pubkey/seckey re-encoding and `classify_chain_outcome` for the timeout / exit-code translation. A dedicated `chain.place_batch_timeout_ms` config knob bounds the per-call wait; `ApiConfig::validate` pins `server.request_timeout_ms > chain.place_batch_timeout_ms` at boot so the HTTP timeout cannot fire while a batch submission is still in flight.
 
@@ -468,19 +468,19 @@ Sender boundary: the existing `ChainOrderSender` trait grows a third method `asy
 
 ### Response
 
-One `PENDING_NEW` envelope per accepted item, returned as a flat array in request order (see [api-spec §New Batch Orders](../api-spec.md#new-batch-orders)). The shape is symmetric with `POST /api/v1/order`:
+One `PENDING_NEW` envelope per accepted item, returned as a flat array in request order (see [api-spec §New Batch Orders](../api-spec.md#new-batch-orders)). The shape is symmetric with `POST /api/v1/prediction/order`:
 
 | Field | Source |
 | --- | --- |
 | `clientOrderId` | Per-item: caller-supplied `newOrderClientId`, or the backend-generated value. |
 | `transactTime` | `now_pair()` captured once at the start of the handler, repeated for every item — one chain submission, one moment of acceptance. |
-| `status` | Always `"PENDING_NEW"` — same rationale as the single-order path; the chain-assigned `orderId` arrives later through `/api/v1/openOrders`. |
+| `status` | Always `"PENDING_NEW"` — same rationale as the single-order path; the chain-assigned `orderId` arrives later through `/api/v1/prediction/openOrders`. |
 
 Why minimal: the same argument as POST /order applies item by item — every other field a fully-populated order would carry is already in the request the client just sent, and the only fields the Binance-style shape adds (`orderId`, `executedQty`) cannot be filled honestly under optimistic submission.
 
 ### Failure surface
 
-Same three-class split as `POST /api/v1/order`:
+Same three-class split as `POST /api/v1/prediction/order`:
 
 1. **Pre-submit, surfaced synchronously** — request shape (top-level and per-item), market/outcome resolution, batch size cap, per-item validation. First failure rejects the whole request; mapped per [Batch error mapping](#error-mapping-2).
 
@@ -526,19 +526,19 @@ Use case constructors take trait objects; `services/api/tests/create_batch_order
 
 ### Idempotency and retries
 
-The backend stores no inflight batch state and does not retry on its own. Clients that need at-least-once delivery supply explicit `newOrderClientId` values for each item and re-`POST` on transient errors: the chain rejects any item whose coid is still live as `ERR_INVALID_PARAMS`, reverting the whole batch; once the original batch is no longer in flight, `/api/v1/openOrders` keyed on `clientOrderId` surfaces the eventually-confirmed state.
+The backend stores no inflight batch state and does not retry on its own. Clients that need at-least-once delivery supply explicit `newOrderClientId` values for each item and re-`POST` on transient errors: the chain rejects any item whose coid is still live as `ERR_INVALID_PARAMS`, reverting the whole batch; once the original batch is no longer in flight, `/api/v1/prediction/openOrders` keyed on `clientOrderId` surfaces the eventually-confirmed state.
 
 ### Concurrency
 
 Same per-PN serial constraint as the single-order path — `placeBatch` takes the same `_busy` lock and holds it until `onBatchComplete` arrives. A POST `/batchOrders` racing any other placement or cancellation from the same account surfaces as `OrderPnBusy` → 429 / -2014, with the same retry semantics. Submitting an N-item batch instead of N sequential POSTs is the canonical way to get higher per-account placement throughput — one chain message, one `_busy` lock, one `onBatchComplete` callback.
 
-## `DELETE /api/v1/batchOrders`
+## `DELETE /api/v1/prediction/batchOrders`
 
-The handler runs three phases: request parsing → market/outcome resolution and bulk order resolution → chain submission. Layout mirrors `DELETE /api/v1/order` lifted from one order to N, with the same batch-level resolution gate `POST /api/v1/batchOrders` uses. Each phase fails closed with its own error code (see [Batch cancel error mapping](#error-mapping-3)). The on-chain cancel is optimistic in the same sense as the single-order DELETE: the chain has no standalone batch-cancel method — `PrivateNote.placeBatch` is the atomic batch entry point, and this endpoint dispatches it with an empty placements side (`orders = []`, `cancelIds` populated), forwarding one `OrderBook.executeBatch` message; per-order removal from the book and the projection into [`live_orders`](data-schema.md#live_orders) happen asynchronously through the indexer.
+The handler runs three phases: request parsing → market/outcome resolution and bulk order resolution → chain submission. Layout mirrors `DELETE /api/v1/prediction/order` lifted from one order to N, with the same batch-level resolution gate `POST /api/v1/prediction/batchOrders` uses. Each phase fails closed with its own error code (see [Batch cancel error mapping](#error-mapping-3)). The on-chain cancel is optimistic in the same sense as the single-order DELETE: the chain has no standalone batch-cancel method — `PrivateNote.placeBatch` is the atomic batch entry point, and this endpoint dispatches it with an empty placements side (`orders = []`, `cancelIds` populated), forwarding one `OrderBook.executeBatch` message; per-order removal from the book and the projection into [`live_orders`](data-schema.md#live_orders) happen asynchronously through the indexer.
 
 ### Authorization
 
-Same hoop as `POST /api/v1/batchOrders`. The handler calls `require_auth(depot, Permission::Trade)` and reads the resolved [`TradingPn`](auth.md#trading-private-note) out of `AuthContext`. The whole batch is signed by one trading-PN keypair — the chain ABI takes one external message and the busy lock is per-PN regardless of batch size.
+Same hoop as `POST /api/v1/prediction/batchOrders`. The handler calls `require_auth(depot, Permission::Trade)` and reads the resolved [`TradingPn`](auth.md#trading-private-note) out of `AuthContext`. The whole batch is signed by one trading-PN keypair — the chain ABI takes one external message and the busy lock is per-PN regardless of batch size.
 
 ### Request parsing
 
@@ -548,7 +548,7 @@ Top-level body fields:
 
 | Field | Type | Notes |
 | --- | --- | --- |
-| `marketAddress` | `MarketAddress` | Mandatory. |
+| `predictionMarketAddress` | `MarketAddress` | Mandatory. |
 | `symbol` | `Symbol` | Mandatory. |
 | `orderIds` | `Vec<String>` | Mandatory and non-empty. Maximum length equals the configured `chain.max_batch_size`. Each element is parsed as `u64::from_str` in the handler (`build_cancel_batch_orders_input`); out-of-range or non-numeric → `InvalidParameter` → 400 / -1130 — same `arbitrary_precision` constraint documented for the single-order path. A blank or whitespace-only element is treated as an absent slot and surfaces as `MissingParameter` → 400 / -1102, matching the single-order DELETE's handling of a blank `orderId`. |
 
@@ -556,7 +556,7 @@ Intra-batch duplicate `orderId` values are rejected with `InvalidParameter` → 
 
 ### Market and outcome resolution
 
-`(marketAddress, symbol)` is resolved once via the same `resolve_for_new_order` join the placement paths use, including the visibility gate (`m.last_reconciled_at IS NOT NULL`) and the [Status derivation](read-api.md#status-derivation) clause. A miss surfaces as `InvalidMarketOrSymbol` → 404. Cancellation is permitted only when `status == TRADING`; any other phase rejects with `OrderValidationFailed` → 400 — same gate as the single-order DELETE. A reconciled market with NULL/blank `oracle_list_hash` surfaces as `MarketInconsistent` → 503.
+`(predictionMarketAddress, symbol)` is resolved once via the same `resolve_for_new_order` join the placement paths use, including the visibility gate (`m.last_reconciled_at IS NOT NULL`) and the [Status derivation](read-api.md#status-derivation) clause. A miss surfaces as `InvalidMarketOrSymbol` → 404. Cancellation is permitted only when `status == TRADING`; any other phase rejects with `OrderValidationFailed` → 400 — same gate as the single-order DELETE. A reconciled market with NULL/blank `oracle_list_hash` surfaces as `MarketInconsistent` → 503.
 
 The resolved row supplies the chain-level fields once for the whole batch:
 
@@ -568,7 +568,7 @@ The resolved row supplies the chain-level fields once for the whole batch:
 
 ### Batch size cap
 
-Sourced from the api config knob `chain.max_batch_size`, same as `POST /api/v1/batchOrders`. The chain's own `MAX_BATCH_SIZE` (10 today, applied independently to the `orders` and `cancelIds` sides of `placeBatch`) is the ceiling the configured value must not exceed; serving `/api/v1/markets` from the same knob keeps the public surface aligned with the enforcement. An empty `orderIds[]` or one whose length exceeds the cap surfaces as `InvalidParameter` → 400 / -1130 before the chain submission.
+Sourced from the api config knob `chain.max_batch_size`, same as `POST /api/v1/prediction/batchOrders`. The chain's own `MAX_BATCH_SIZE` (10 today, applied independently to the `orders` and `cancelIds` sides of `placeBatch`) is the ceiling the configured value must not exceed; serving `/api/v1/prediction/markets` from the same knob keeps the public surface aligned with the enforcement. An empty `orderIds[]` or one whose length exceeds the cap surfaces as `InvalidParameter` → 400 / -1130 before the chain submission.
 
 ### Order resolution
 
@@ -577,7 +577,7 @@ One SELECT joins [`live_orders`](data-schema.md#live_orders) against `markets �
 - Scoping to the resolved outcome's book goes through the `markets ⨝ live_orders` join on `orderbook_address`, mirrored on the single-cancel path.
 - `live_orders.owner_pn_address = :pn_address` — pins the caller as the owner of every row.
 - `live_orders.order_id` filtered against the input list via `lo.order_id = ANY($3::text[]::numeric[])` — the cast happens on the bind-side array (once at planning), so the indexed `numeric` column is compared without a per-row functional expression and the `(orderbook_address, order_id)` primary key remains usable for the per-id lookup. The SELECT projects `lo.order_id::text` for the application layer to parse back into `u64` and key the resolution `HashMap` on the natural chain identity — no positional `bind_idx` is round-tripped through the wire.
-- `live_orders.status = 'OPEN'` AND `live_orders.amount_remaining > 0` — same belt-and-suspenders pair as `/api/v1/openOrders` and single-order DELETE; keeps the transient `OPEN`/`amount_remaining = 0` slice invisible to cancel.
+- `live_orders.status = 'OPEN'` AND `live_orders.amount_remaining > 0` — same belt-and-suspenders pair as `/api/v1/prediction/openOrders` and single-order DELETE; keeps the transient `OPEN`/`amount_remaining = 0` slice invisible to cancel.
 
 The SELECT also returns each row's `live_orders.client_order_id` (echoed in the response). The use case asserts `resolution.orders.len() < input.order_ids.len()` is false; any shortfall — unknown id, wrong owner, wrong book, already closed — surfaces as `UnknownOrder` → 404 / -2011 for the whole batch, with the same deliberate opacity as single-order DELETE (differentiating those cases would leak order existence and account binding). Validation is atomic: no chain message is sent if any item is unresolved.
 
@@ -605,7 +605,7 @@ Sender boundary: `ChainOrderSender::cancel_batch_order(&self, payload: CancelBat
 
 ### Response
 
-One `PENDING_CANCEL` envelope per accepted item, returned as a flat array in request order (see [api-spec §Cancel Batch Orders](../api-spec.md#cancel-batch-orders)). Shape is symmetric with `DELETE /api/v1/order`:
+One `PENDING_CANCEL` envelope per accepted item, returned as a flat array in request order (see [api-spec §Cancel Batch Orders](../api-spec.md#cancel-batch-orders)). Shape is symmetric with `DELETE /api/v1/prediction/order`:
 
 | Field | Source |
 | --- | --- |
@@ -616,7 +616,7 @@ One `PENDING_CANCEL` envelope per accepted item, returned as a flat array in req
 
 ### Failure surface
 
-Three failure classes — two synchronous, one async — same split as `DELETE /api/v1/order` and `POST /api/v1/batchOrders`.
+Three failure classes — two synchronous, one async — same split as `DELETE /api/v1/prediction/order` and `POST /api/v1/prediction/batchOrders`.
 
 1. **Pre-submit, surfaced synchronously** — request shape, market/outcome resolution, batch size cap, intra-batch duplicate check, bulk order resolution. First failure rejects the whole request; no chain message is sent. Mapped per [Batch cancel error mapping](#error-mapping-3).
 
@@ -628,7 +628,7 @@ Three failure classes — two synchronous, one async — same split as `DELETE /
    | `161` `ERR_BATCH_TOO_LARGE` / `162` `ERR_EMPTY_BATCH` | chain-side defence-in-depth — reaching either code means the configured `chain.max_batch_size` drifted above the on-chain ceiling, not a client bug | `MarketInconsistent` → 503 / -1500 |
    | any other `tvm_exit` code | unmapped chain code | `Unexpected` → 500 / -1000, logged at `error` for ops triage |
 
-3. **OrderBook chain-side, surfaced asynchronously** — `OrderBook.executeBatch` processes the cancels from its internal queue in a later transaction. The single-order DELETE's three async outcomes (race with fill/earlier cancel, owner mismatch under read-model corruption, queue overflow) extend to the batch case **per order**: the batch as a whole can have some ids land as `CANCELED`, some as `FILLED` (matching raced the cancel), and — under queue overflow — some remain `OPEN`. The indexer projects each outcome independently into `live_orders` (stored status `CANCELLED` / `FILLED`); clients reconcile by polling `/api/v1/orders`, which surfaces each id with the public-spec status `CANCELED` or `FILLED`.
+3. **OrderBook chain-side, surfaced asynchronously** — `OrderBook.executeBatch` processes the cancels from its internal queue in a later transaction. The single-order DELETE's three async outcomes (race with fill/earlier cancel, owner mismatch under read-model corruption, queue overflow) extend to the batch case **per order**: the batch as a whole can have some ids land as `CANCELED`, some as `FILLED` (matching raced the cancel), and — under queue overflow — some remain `OPEN`. The indexer projects each outcome independently into `live_orders` (stored status `CANCELLED` / `FILLED`); clients reconcile by polling `/api/v1/prediction/orders`, which surfaces each id with the public-spec status `CANCELED` or `FILLED`.
 
    An HTTP 200 `PENDING_CANCEL` array is therefore not a guarantee that every cancel will land — it confirms only that `PrivateNote.placeBatch` accepted the request.
 
@@ -664,7 +664,7 @@ Use case constructors take trait objects; `services/api/tests/cancel_batch_order
 
 ### Idempotency and retries
 
-The backend stores no inflight cancel state and does not retry on its own. Duplicate `DELETE /api/v1/batchOrders` calls on overlapping `orderIds` sets are safe at the chain level by the same argument as single-order DELETE applied per id:
+The backend stores no inflight cancel state and does not retry on its own. Duplicate `DELETE /api/v1/prediction/batchOrders` calls on overlapping `orderIds` sets are safe at the chain level by the same argument as single-order DELETE applied per id:
 
 - If the first batch is still in flight at PN, the second hits `ERR_NOTE_BUSY` → 429 (retry).
 - If the first batch already cleared PN but the indexer has not flipped `live_orders` yet, the second passes pre-submit, PN forwards a second `executeBatch`, OrderBook's per-id `_doCancel` silently no-ops on ids already gone, and the indexer state remains consistent.
@@ -674,13 +674,13 @@ The backend stores no inflight cancel state and does not retry on its own. Dupli
 
 Same per-PN serial constraint as the single-order paths and the placement batch — the cancel-only `placeBatch` takes the `_busy` lock and holds it until `onBatchComplete` arrives. A DELETE `/batchOrders` racing any other placement or cancellation from the same account surfaces as `OrderPnBusy` → 429 / -2014. Submitting one batch instead of N sequential DELETEs is the canonical way to cancel multiple orders without per-call back-pressure today — one chain message, one `_busy` lock, one `onBatchComplete` callback.
 
-## `DELETE /api/v1/openOrders`
+## `DELETE /api/v1/prediction/openOrders`
 
 See [api-spec §Cancel All Open Orders On Symbol](../api-spec.md#cancel-all-open-orders-on-symbol) for the public contract.
 
 _Implementation tech spec to be filled in._
 
-## `POST /api/v1/buyFullSet`
+## `POST /api/v1/prediction/buyFullSet`
 
 Buys a full set of outcome tokens for one market by depositing `collateral` of the market's quote asset into the PMP. The chain entry point is `PrivateNote.splitFullSet`; on a market sitting in `AWAITING_FREEZE` the first successful call also activates the OrderBook, after which it stays active for all subsequent callers. From the caller's standpoint the request and response are identical to any later call against the same market.
 
@@ -694,14 +694,14 @@ Same hoop as the order endpoints. The handler calls `require_auth(depot, Permiss
 
 | Field | Type | Notes |
 | --- | --- | --- |
-| `marketAddress` | `MarketAddress` | Mandatory. |
+| `predictionMarketAddress` | `MarketAddress` | Mandatory. |
 | `collateral` | `String` | Mandatory; decimal. Kept as a string until quote-asset precision validation. |
 
 Mandatory-field absence (the field missing or trimming to the empty string) returns `MissingParameter` → 400.
 
 ### Market resolution
 
-Resolve `marketAddress` via [`markets`](data-schema.md#markets), filtered by `m.last_reconciled_at IS NOT NULL` — same visibility gate as [`/api/v1/markets`](read-api.md#visibility-filter). No `market_outcomes` join: `splitFullSet` operates at the market level (collateral → one outcome token of every outcome), so there is no per-outcome resolution to perform. A miss surfaces as `InvalidMarketOrSymbol` → 404 / -1121.
+Resolve `predictionMarketAddress` via [`markets`](data-schema.md#prediction-markets), filtered by `m.last_reconciled_at IS NOT NULL` — same visibility gate as [`/api/v1/prediction/markets`](read-api.md#visibility-filter). No `market_outcomes` join: `splitFullSet` operates at the market level (collateral → one outcome token of every outcome), so there is no per-outcome resolution to perform. A miss surfaces as `InvalidMarketOrSymbol` → 404 / -1121.
 
 Derive `status` from the row and the request `now` using the logic in [read-api.md §Status derivation](read-api.md#status-derivation). Per [api-spec §Buy Full Set](../api-spec.md#buy-full-set), the call is permitted only when `status ∈ { AWAITING_FREEZE, TRADING }`; every other phase rejects with `OrderValidationFailed` → 400 / -2010.
 
@@ -761,7 +761,7 @@ A successful submission returns the minimal two-field body from [api-spec §Buy 
 
 | Field | Source |
 | --- | --- |
-| `marketAddress` | Echoed from the request. |
+| `predictionMarketAddress` | Echoed from the request. |
 | `transactTime` | `now_pair()` captured once at the start of the handler. |
 
 Why minimal: the resulting collateral debit and per-outcome credits become visible through [`GET /api/v1/account`](read-api.md) and [`GET /api/v1/account/balances`](read-api.md) once the chain confirms — the synchronous response confirms acceptance only. There is no chain-assigned identifier the response could carry that the caller does not already have.
@@ -784,7 +784,7 @@ Transport-level failures collapse to `Unexpected` → 500 / -1000 with the raw `
 | --- | --- | --- |
 | Auth envelope / unknown api_key / bad signature / timestamp | handled upstream by [auth_hoop](auth.md#authentication) | 401 |
 | Caller lacks `TRADE` permission | `AuthRequired` | 401 |
-| `marketAddress` or `collateral` missing | `MissingParameter` | 400 |
+| `predictionMarketAddress` or `collateral` missing | `MissingParameter` | 400 |
 | `collateral` not positive, exceeds quote-asset precision, non-numeric, or lifted above `u64::MAX` | `InvalidParameter` | 400 |
 | Market unknown or pre-reconcile | `InvalidMarketOrSymbol` | 404 |
 | Reconciled market with NULL/blank `oracle_list_hash`, or quote `token_type` absent from `ref_tokens` | `MarketInconsistent` | 503 |


### PR DESCRIPTION
Namespaces the current prediction-market REST API under `/api/v1/prediction/`, ahead of adding the inference API. **Docs only**, existing endpoints only — no inference, no contract changes.

## Changes (`docs/`)
- **Paths** → `/api/v1/prediction/*`: `markets`, `depth`, `trades`, `order` (POST/DELETE), `orders`, `batchOrders`, `openOrders`, `buyFullSet`, `sellFullSet`, `claim`; and `/ws/v1/user` → `/ws/v1/prediction/user`.
- **Shared, kept at top level**: `/api/v1/oracles`, `/api/v1/account`, `/api/v1/accounts`, `/api/v1/account/balances`.
- **Headings**: `Prediction Market Data` / `Prediction Markets` / `Prediction Order Book` / `Prediction Trades` / `Prediction Position` / `Prediction Trading` / `Prediction WebSocket`; **Oracles** promoted to its own top-level section (shared, no longer nested under market data).
- **Fields**: `marketAddress` → `predictionMarketAddress`, `orderBookAddress` → `predictionOrderBookAddress`.
- Anchors, cross-references, TOC, and the endpoint summary updated to match.

## Not touched
- `docs/openapi.yaml` — generated from handler annotations (`openapi/generate.sh`); it migrates when the route code changes.
- DB columns (`orderbook_address`, `pmp_address`) and the contract getter `getOrderBookAddress()` — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)