### PR TITLE
dexdo: create-prediction-market + submit-resolve (full market lifecycle)

### DIFF
--- a/sdk/src/bin/dexdo.rs
+++ b/sdk/src/bin/dexdo.rs
@@ -74,6 +74,9 @@ const DEPLOYER_SEED_AMOUNT: u128 = 100_000_000_000; // 100 NACKL seeded per outc
 const EVENT_DEADLINE: u64 = 2_000_000_000; // event service deadline (far future)
 const ROOT_ORACLE_NATIVE_TARGET: u64 = 120_000_000_000;
 const ROOT_ORACLE_NATIVE_THRESHOLD: u64 = 50_000_000_000;
+// Timing constants taken from the contract (dex/modifiers/modifiers.sol + PMP.sol).
+const MIN_RESULT_GAP: u64 = 120; // PMP.setTimings requires resultStart >= now + this
+const DEFAULT_RESULT_GAP: u64 = 3000; // default resultStart = now + this when --result-start omitted
 
 // ----------------------------- arg parsing -----------------------------
 
@@ -672,12 +675,14 @@ async fn cmd_create_prediction_market(f: Flags) -> ExitCode {
     if outcome_list.len() < 2 {
         return fail("need at least 2 outcomes (--outcomes \"Yes,No\")");
     }
-    // Length of the STAKING window in seconds (result_start = now + this).
-    let stake_seconds: u64 = match f.get("stake-seconds").map(str::parse::<u64>) {
-        Some(Ok(v)) if v >= 60 => v,
-        Some(Ok(_)) => return fail("--stake-seconds must be >= 60"),
-        Some(Err(_)) => return fail("--stake-seconds must be an integer"),
-        None => 600,
+    // The contract's own `submitSetTimings(resultStart)` parameter (unix seconds).
+    // Optional override; if omitted we default to now + DEFAULT_RESULT_GAP. The
+    // contract derives the rest: stakeEnd = stakeStart + (resultStart-stakeStart)/10,
+    // resultEnd = resultStart + GRACE_PERIOD. We do NOT invent our own window.
+    let result_start_override: Option<u64> = match f.get("result-start").map(str::parse::<u64>) {
+        Some(Ok(v)) => Some(v),
+        Some(Err(_)) => return fail("--result-start must be a unix timestamp (seconds)"),
+        None => None,
     };
 
     let token_type = proof::TokenType::Nackl as u32;
@@ -824,8 +829,18 @@ async fn cmd_create_prediction_market(f: Flags) -> ExitCode {
     // 5. Oracle sets the staking timings → market opens for STAKING.
     //    result_start = now + window; the contract derives the stake window from it.
     let now = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0);
-    let result_start = now + stake_seconds;
-    eprintln!("[dexdo create-prediction-market] submitSetTimings(result_start={result_start}, window={stake_seconds}s)…");
+    let result_start = result_start_override.unwrap_or(now + DEFAULT_RESULT_GAP);
+    // Mirror the contract's first-call guard so we fail early with a clear message.
+    if result_start < now + MIN_RESULT_GAP {
+        return fail(&format!(
+            "--result-start must be >= now + {MIN_RESULT_GAP}s (contract MIN_RESULT_GAP); got {result_start}, now {now}"
+        ));
+    }
+    // Contract derives the STAKING window as (resultStart - stakeStart)/10.
+    let approx_stake_window = result_start.saturating_sub(now) / 10;
+    eprintln!(
+        "[dexdo create-prediction-market] submitSetTimings(resultStart={result_start}) → ~{approx_stake_window}s STAKING window…"
+    );
     let mut timings_ok = false;
     for attempt in 0..6 {
         match dx
@@ -908,11 +923,14 @@ fn usage() -> String {
        pmp-details   --market-address 0:<pmp> [--endpoint host]\n                  \
        Read a market's phase window, outcomes, and identity (read-only).\n  \
        create-prediction-market  --pn-state-file <path> [--name <prefix>] \
-     [--outcomes \"A,B\"] [--stake-seconds N] [--endpoint host]\n                  \
+     [--outcomes \"A,B\"] [--result-start <unix>] [--endpoint host]\n                  \
        Deploy a fresh oracle + event + PMP (one prediction market) using the funded \
      deployer note, then open STAKING (oracle submitSetTimings). Prints \
-     predictionMarketAddress + oracleSecretHex (keep — needed to resolve) + windows. \
-     NOTE: the contract caps the STAKING window short (~90s), so stake promptly.\n\n\
+     predictionMarketAddress + oracleSecretHex (keep — needed to resolve) + windows.\n                  \
+       --result-start is the contract's resultStart param (unix seconds); must be \
+     >= now + 120 (MIN_RESULT_GAP). The contract derives stakeEnd = stakeStart + \
+     (resultStart-stakeStart)/10 and resultEnd = resultStart + 86400, so the STAKING \
+     window is ~1/10 of (resultStart - now). Default: now + 3000 (~5-min window).\n\n\
      common flags:\n  \
        --endpoint    network host (default shellnet.ackinacki.org)\n"
         .to_string()

--- a/sdk/src/bin/dexdo.rs
+++ b/sdk/src/bin/dexdo.rs
@@ -58,6 +58,7 @@ use dodex_contracts::dex::oracle::Oracle;
 use dodex_contracts::dex::oracle::ParamsOfGetEventListAddress;
 use dodex_contracts::dex::oracle_event_list::OracleEventList;
 use dodex_contracts::dex::oracle_event_list::ParamsOfAddEvent;
+use dodex_contracts::dex::pmp::ParamsOfSubmitResolve;
 use dodex_contracts::dex::pmp::ParamsOfSubmitSetTimings;
 use dodex_contracts::dex::pmp::Pmp;
 use dodex_contracts::dex::private_note::ParamsOfDeployPmp;
@@ -684,6 +685,13 @@ async fn cmd_create_prediction_market(f: Flags) -> ExitCode {
         Some(Err(_)) => return fail("--result-start must be a unix timestamp (seconds)"),
         None => None,
     };
+    // Relative convenience: result_start = (now, measured AFTER deploy) + this.
+    // Lets you control the resolve gap without guessing the deploy duration.
+    let result_in: Option<u64> = match f.get("result-in").map(str::parse::<u64>) {
+        Some(Ok(v)) => Some(v),
+        Some(Err(_)) => return fail("--result-in must be an integer (seconds from now)"),
+        None => None,
+    };
 
     let token_type = proof::TokenType::Nackl as u32;
     let context = create_tvm_context(&endpoint);
@@ -829,7 +837,11 @@ async fn cmd_create_prediction_market(f: Flags) -> ExitCode {
     // 5. Oracle sets the staking timings → market opens for STAKING.
     //    result_start = now + window; the contract derives the stake window from it.
     let now = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0);
-    let result_start = result_start_override.unwrap_or(now + DEFAULT_RESULT_GAP);
+    let result_start = match (result_start_override, result_in) {
+        (Some(v), _) => v,
+        (None, Some(rin)) => now + rin,
+        (None, None) => now + DEFAULT_RESULT_GAP,
+    };
     // Mirror the contract's first-call guard so we fail early with a clear message.
     if result_start < now + MIN_RESULT_GAP {
         return fail(&format!(
@@ -869,12 +881,28 @@ async fn cmd_create_prediction_market(f: Flags) -> ExitCode {
         Err(e) => return fail(&format!("get_pmp_details after timings: {e:?}")),
     };
 
+    // Persist the oracle keypair next to the deployer note so this market can be
+    // resolved later with `dexdo submit-resolve --oracle-keys <file>`.
+    let keys_path = std::path::Path::new(&state)
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("."))
+        .join(format!("{oracle_name}.oracle.keys.json"));
+    let keys_json =
+        serde_json::json!({ "public": oracle_keys.public, "secret": oracle_keys.secret });
+    if let Err(e) =
+        std::fs::write(&keys_path, serde_json::to_string_pretty(&keys_json).unwrap_or_default())
+    {
+        eprintln!("[dexdo create-prediction-market] WARN could not write oracle keys file: {e}");
+    }
+
     let out = serde_json::json!({
         "predictionMarketAddress": pmp_address,
         "oracleAddress": oracle_address,
         "oracleName": oracle_name,
         // KEEP SECRET — the oracle key is needed to `submit_resolve` this market later.
+        "oraclePublicHex": oracle_keys.public,
         "oracleSecretHex": oracle_keys.secret,
+        "oracleKeysFile": keys_path.display().to_string(),
         "eventId": event_id,
         "tokenType": token_type,
         "outcomes": outcome_list,
@@ -889,6 +917,57 @@ async fn cmd_create_prediction_market(f: Flags) -> ExitCode {
     println!("{}", serde_json::to_string_pretty(&out).unwrap_or_else(|_| "{}".into()));
     eprintln!("[dexdo create-prediction-market] DONE predictionMarketAddress={pmp_address} approved={}", details.approved);
     ExitCode::SUCCESS
+}
+
+/// Load the oracle keypair for `submit-resolve`: from `--oracle-keys <file>`
+/// (a JSON `{public, secret}`, e.g. the one `create-prediction-market` writes)
+/// or from explicit `--oracle-public <hex> --oracle-secret <hex>`.
+fn load_oracle_keys(f: &Flags) -> Result<KeyPair, String> {
+    if let Some(path) = f.get("oracle-keys") {
+        let raw = std::fs::read_to_string(path).map_err(|e| format!("read --oracle-keys {path}: {e}"))?;
+        let v: serde_json::Value =
+            serde_json::from_str(&raw).map_err(|e| format!("parse {path}: {e}"))?;
+        let public = v.get("public").and_then(|x| x.as_str()).ok_or("oracle-keys file missing `public`")?;
+        let secret = v.get("secret").and_then(|x| x.as_str()).ok_or("oracle-keys file missing `secret`")?;
+        return Ok(KeyPair { public: public.to_string(), secret: secret.to_string() });
+    }
+    let public = f.get("oracle-public").ok_or("need --oracle-keys <file> or --oracle-public/--oracle-secret")?;
+    let secret = f.get("oracle-secret").ok_or("need --oracle-secret with --oracle-public")?;
+    Ok(KeyPair { public: public.to_string(), secret: secret.to_string() })
+}
+
+/// `dexdo submit-resolve` — resolve a market you hold the oracle key for.
+/// Sends `PMP.submitResolve(outcomeId)` signed by the oracle key. The single
+/// oracle is a quorum of 1, so one call resolves the market. Valid only in the
+/// resolve window: `resultStart <= now <= resultStart + GRACE_PERIOD` (else the
+/// contract reverts ERR_RESULT_NOT_STARTED / ERR_RESULT_ENDED).
+async fn cmd_submit_resolve(f: Flags) -> ExitCode {
+    let endpoint = f.endpoint();
+    let market = match f.require("market-address") { Ok(v) => v.to_string(), Err(e) => return fail(&e) };
+    let outcome: u32 = match f.require("outcome").map(str::parse::<u32>) {
+        Ok(Ok(v)) => v,
+        Ok(Err(_)) => return fail("--outcome must be a non-negative integer"),
+        Err(e) => return fail(&e),
+    };
+    let keys = match load_oracle_keys(&f) { Ok(k) => k, Err(e) => return fail(&e) };
+    let dx = match dex(&endpoint) { Ok(d) => d, Err(e) => return fail(&e) };
+    eprintln!("[dexdo submit-resolve] market={market} outcome={outcome}");
+    match dx
+        .submit_resolve(&market, ParamsOfSubmitResolve { outcome_id: outcome }, Signer::Keys { keys })
+        .await
+    {
+        Ok(_) => {
+            let out = serde_json::json!({
+                "predictionMarketAddress": market,
+                "resolvedOutcomeId": outcome,
+                "status": "submitResolve sent (quorum 1 → resolved)",
+            });
+            println!("{}", serde_json::to_string_pretty(&out).unwrap_or_else(|_| "{}".into()));
+            eprintln!("[dexdo submit-resolve] DONE outcome={outcome}");
+            ExitCode::SUCCESS
+        }
+        Err(e) => fail(&format!("submit_resolve: {e:?}")),
+    }
 }
 
 // ----------------------------- dispatch -----------------------------
@@ -923,14 +1002,19 @@ fn usage() -> String {
        pmp-details   --market-address 0:<pmp> [--endpoint host]\n                  \
        Read a market's phase window, outcomes, and identity (read-only).\n  \
        create-prediction-market  --pn-state-file <path> [--name <prefix>] \
-     [--outcomes \"A,B\"] [--result-start <unix>] [--endpoint host]\n                  \
+     [--outcomes \"A,B\"] [--result-start <unix> | --result-in <secs>] [--endpoint host]\n                  \
        Deploy a fresh oracle + event + PMP (one prediction market) using the funded \
      deployer note, then open STAKING (oracle submitSetTimings). Prints \
      predictionMarketAddress + oracleSecretHex (keep — needed to resolve) + windows.\n                  \
        --result-start is the contract's resultStart param (unix seconds); must be \
      >= now + 120 (MIN_RESULT_GAP). The contract derives stakeEnd = stakeStart + \
      (resultStart-stakeStart)/10 and resultEnd = resultStart + 86400, so the STAKING \
-     window is ~1/10 of (resultStart - now). Default: now + 3000 (~5-min window).\n\n\
+     window is ~1/10 of (resultStart - now). Default: now + 3000 (~5-min window).\n  \
+       submit-resolve  --market-address 0:<pmp> --outcome <id> \
+     (--oracle-keys <file> | --oracle-public <hex> --oracle-secret <hex>) [--endpoint host]\n                  \
+       Resolve a market you own the oracle key for (PMP.submitResolve, quorum 1). \
+     Valid only in the resolve window: resultStart <= now <= resultStart + 86400. \
+     After it resolves, stakers claim then withdraw.\n\n\
      common flags:\n  \
        --endpoint    network host (default shellnet.ackinacki.org)\n"
         .to_string()
@@ -952,6 +1036,7 @@ async fn dispatch(sub: &str, rest: &[String]) -> ExitCode {
         "withdraw" => cmd_withdraw(flags).await,
         "pmp-details" => cmd_pmp_details(flags).await,
         "create-prediction-market" => cmd_create_prediction_market(flags).await,
+        "submit-resolve" => cmd_submit_resolve(flags).await,
         other => fail(&format!("unknown subcommand `{other}`\n\n{}", usage())),
     }
 }

--- a/sdk/src/bin/dexdo.rs
+++ b/sdk/src/bin/dexdo.rs
@@ -43,7 +43,37 @@ use dodex_sdk::Dex;
 use dodex_sdk::DexConfig;
 use serde::Deserialize;
 
+// create-prediction-market deps (oracle + event + PMP deploy)
+use std::sync::Arc;
+use ackinacki_kit::contracts::account::AccountStatus;
+use ackinacki_kit::contracts::account::ParamsOfWaitAccount;
+use ackinacki_kit::contracts::giver::v3::top_up_native_with_giver_if_below;
+use ackinacki_kit::contracts::traits::AccountAccessor;
+use ackinacki_kit::tvm_client::crypto;
+use ackinacki_kit::tvm_client::crypto::ParamsOfMnemonicDeriveSignKeys;
+use ackinacki_kit::tvm_client::crypto::ParamsOfMnemonicFromRandom;
+use ackinacki_kit::tvm_client::ClientConfig;
+use ackinacki_kit::tvm_client::ClientContext;
+use dodex_contracts::dex::oracle::Oracle;
+use dodex_contracts::dex::oracle::ParamsOfGetEventListAddress;
+use dodex_contracts::dex::oracle_event_list::OracleEventList;
+use dodex_contracts::dex::oracle_event_list::ParamsOfAddEvent;
+use dodex_contracts::dex::pmp::ParamsOfSubmitSetTimings;
+use dodex_contracts::dex::pmp::Pmp;
+use dodex_contracts::dex::private_note::ParamsOfDeployPmp;
+use dodex_contracts::dex::root_oracle::ParamsOfDeployOracle;
+use dodex_contracts::dex::root_oracle::RootOracle;
+use dodex_sdk::dex_contract_params;
+use dodex_sdk::proof;
+
 const DEFAULT_ENDPOINT: &str = "shellnet.ackinacki.org";
+
+// create-prediction-market constants (mirror the e2e setup defaults).
+const ORACLE_FEE: u128 = 100;
+const DEPLOYER_SEED_AMOUNT: u128 = 100_000_000_000; // 100 NACKL seeded per outcome
+const EVENT_DEADLINE: u64 = 2_000_000_000; // event service deadline (far future)
+const ROOT_ORACLE_NATIVE_TARGET: u64 = 120_000_000_000;
+const ROOT_ORACLE_NATIVE_THRESHOLD: u64 = 50_000_000_000;
 
 // ----------------------------- arg parsing -----------------------------
 
@@ -591,6 +621,261 @@ async fn cmd_withdraw(f: Flags) -> ExitCode {
     }
 }
 
+// ------------------- create-prediction-market helpers -------------------
+
+fn create_tvm_context(endpoint: &str) -> Arc<ClientContext> {
+    let mut config = ClientConfig::default();
+    config.network.endpoints = Some(vec![endpoint.to_string()]);
+    Arc::new(ClientContext::new(config).expect("create context"))
+}
+
+/// Fresh 24-word signing keypair (oracle / ephemeral deploy-signer).
+fn gen_keys(context: Arc<ClientContext>) -> KeyPair {
+    let phrase = crypto::mnemonic_from_random(
+        context.clone(),
+        ParamsOfMnemonicFromRandom { dictionary: None, word_count: Some(24) },
+    )
+    .expect("mnemonic")
+    .phrase;
+    crypto::mnemonic_derive_sign_keys(
+        context,
+        ParamsOfMnemonicDeriveSignKeys { phrase, path: None, dictionary: None, word_count: Some(24) },
+    )
+    .expect("derive keys")
+}
+
+async fn wait_active<T: AccountAccessor>(contract: &T, label: &str) -> Result<(), String> {
+    contract
+        .wait_account(ParamsOfWaitAccount {
+            status: AccountStatus::Active,
+            attempts: Some(30),
+            attempts_timeout: Some(2_000),
+        })
+        .await
+        .map(|_| ())
+        .map_err(|e| format!("wait {label} active: {e:?}"))
+}
+
+/// `dexdo create-prediction-market` — deploy a fresh oracle + event + PMP
+/// (one prediction market) using a funded deployer note, then print the
+/// `predictionMarketAddress` + identity + staking window. The deployer note
+/// seeds the initial stakes, so after this it already holds positions —
+/// recover them with `cancel-stake` (while STAKING) + `withdraw`.
+async fn cmd_create_prediction_market(f: Flags) -> ExitCode {
+    let endpoint = f.endpoint();
+    let state = match f.require("pn-state-file") { Ok(v) => v.to_string(), Err(e) => return fail(&e) };
+    let (pn_address, pn_keys) = match load_pn(&state) { Ok(v) => v, Err(e) => return fail(&e) };
+    let name_prefix = f.get("name").unwrap_or("dexdo-pm").to_string();
+    let outcomes_arg = f.get("outcomes").unwrap_or("Yes,No").to_string();
+    let outcome_list: Vec<String> =
+        outcomes_arg.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect();
+    if outcome_list.len() < 2 {
+        return fail("need at least 2 outcomes (--outcomes \"Yes,No\")");
+    }
+    // Length of the STAKING window in seconds (result_start = now + this).
+    let stake_seconds: u64 = match f.get("stake-seconds").map(str::parse::<u64>) {
+        Some(Ok(v)) if v >= 60 => v,
+        Some(Ok(_)) => return fail("--stake-seconds must be >= 60"),
+        Some(Err(_)) => return fail("--stake-seconds must be an integer"),
+        None => 600,
+    };
+
+    let token_type = proof::TokenType::Nackl as u32;
+    let context = create_tvm_context(&endpoint);
+    let dx = match dex(&endpoint) { Ok(d) => d, Err(e) => return fail(&e) };
+
+    let oracle_keys = gen_keys(context.clone());
+    let ephemeral_keys = gen_keys(context.clone());
+    let run_id = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0);
+    let oracle_name = format!("{name_prefix}-{run_id:x}");
+    eprintln!(
+        "[dexdo create-prediction-market] oracle={oracle_name} outcomes={outcome_list:?} deployer={pn_address}"
+    );
+
+    // RootOracle needs gas to materialize the Oracle.
+    let root_oracle =
+        RootOracle::new(context.clone(), dex_contract_params(RootOracle::DEFAULT_ADDRESS));
+    if let Err(e) = wait_active(&root_oracle, "RootOracle").await { return fail(&e); }
+    if let Err(e) = top_up_native_with_giver_if_below(
+        context.clone(),
+        &root_oracle,
+        ROOT_ORACLE_NATIVE_TARGET,
+        ROOT_ORACLE_NATIVE_THRESHOLD,
+        "RootOracle",
+    )
+    .await
+    {
+        return fail(&format!("top up RootOracle: {e:?}"));
+    }
+
+    // 1. Deploy oracle (ephemeral signer; on-chain pubkey is the oracle key).
+    if let Err(e) = dx
+        .deploy_oracle(
+            ParamsOfDeployOracle {
+                oracle_pubkey: proof::pubkey_to_dec(&oracle_keys.public),
+                oracle_name: oracle_name.clone(),
+            },
+            Signer::Keys { keys: ephemeral_keys },
+        )
+        .await
+    {
+        return fail(&format!("deploy_oracle: {e:?}"));
+    }
+    let oracle_address = match dx.get_oracle_address(oracle_name.clone()).await {
+        Ok(a) => a,
+        Err(e) => return fail(&format!("get_oracle_address: {e:?}")),
+    };
+    let oracle_contract = Oracle::new(context.clone(), dex_contract_params(&oracle_address));
+    if let Err(e) = wait_active(&oracle_contract, "Oracle").await { return fail(&e); }
+    let el_address = match dx
+        .get_event_list_address(&oracle_address, ParamsOfGetEventListAddress { index: 0 })
+        .await
+    {
+        Ok(a) => a,
+        Err(e) => return fail(&format!("get_event_list_address: {e:?}")),
+    };
+    let el_contract = OracleEventList::new(context.clone(), dex_contract_params(&el_address));
+    if let Err(e) = wait_active(&el_contract, "EventList").await { return fail(&e); }
+
+    // 2. Add the event.
+    let event_name = format!("Match {run_id:x}");
+    let outcome_names: HashMap<u32, String> =
+        outcome_list.iter().enumerate().map(|(i, n)| (i as u32, n.clone())).collect();
+    if let Err(e) = dx
+        .add_event(
+            &el_address,
+            ParamsOfAddEvent {
+                event_name: event_name.clone(),
+                oracle_fee: ORACLE_FEE,
+                deadline: EVENT_DEADLINE,
+                describe: "Who wins?".to_string(),
+                outcome_names,
+                trust_addr: None,
+            },
+            Signer::Keys { keys: oracle_keys.clone() },
+        )
+        .await
+    {
+        return fail(&format!("add_event: {e:?}"));
+    }
+    let mut event_id = String::new();
+    for _ in 0..20 {
+        if let Ok(evs) = dx.get_events(&el_address).await {
+            if let Some((id, _)) = evs
+                .events
+                .iter()
+                .find(|(_, e)| e.get("eventName").and_then(|v| v.as_str()) == Some(event_name.as_str()))
+            {
+                event_id = id.clone();
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    }
+    if event_id.is_empty() {
+        return fail("event did not appear after add_event");
+    }
+
+    // 3. Deploy the PMP (prediction market), signed by the deployer note;
+    //    it seeds the initial stakes for every outcome.
+    let initial_stakes = vec![DEPLOYER_SEED_AMOUNT; outcome_list.len()];
+    if let Err(e) = dx
+        .deploy_pmp(
+            &pn_address,
+            ParamsOfDeployPmp {
+                event_id: event_id.clone(),
+                oracle_fee: vec![ORACLE_FEE],
+                token_type,
+                names: vec![oracle_name.clone()],
+                index: vec![0u128],
+                initial_stakes,
+            },
+            Signer::Keys { keys: pn_keys },
+        )
+        .await
+    {
+        return fail(&format!("deploy_pmp: {e:?}"));
+    }
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    let pmp_address = match dx.get_pmp_address(event_id.clone(), vec![oracle_name.clone()], token_type).await {
+        Ok(a) => a,
+        Err(e) => return fail(&format!("get_pmp_address: {e:?}")),
+    };
+    let pmp_contract = Pmp::new(context.clone(), dex_contract_params(&pmp_address));
+    if let Err(e) = wait_active(&pmp_contract, "PMP").await { return fail(&e); }
+
+    // 4. Wait until the PMP has confirmed the event with the oracle (the oracle
+    //    is registered as trust-addr) — only then will submitSetTimings apply.
+    eprintln!("[dexdo create-prediction-market] waiting for event confirmation…");
+    let mut confirmed = false;
+    for _ in 0..80 {
+        if let Ok(d) = dx.get_pmp_details(&pmp_address).await {
+            if d.number_of_oracle_events > 0 && d.approved_oracle_events >= d.number_of_oracle_events {
+                confirmed = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+    }
+    if !confirmed {
+        return fail("event confirmation never landed (PMP not approved by oracle) — cannot set timings");
+    }
+
+    // 5. Oracle sets the staking timings → market opens for STAKING.
+    //    result_start = now + window; the contract derives the stake window from it.
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0);
+    let result_start = now + stake_seconds;
+    eprintln!("[dexdo create-prediction-market] submitSetTimings(result_start={result_start}, window={stake_seconds}s)…");
+    let mut timings_ok = false;
+    for attempt in 0..6 {
+        match dx
+            .submit_set_timings(
+                &pmp_address,
+                ParamsOfSubmitSetTimings { result_start },
+                Signer::Keys { keys: oracle_keys.clone() },
+            )
+            .await
+        {
+            Ok(_) => { timings_ok = true; break; }
+            Err(e) => {
+                eprintln!("[dexdo create-prediction-market] submit_set_timings attempt {} failed ({e:?}); retrying…", attempt + 1);
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            }
+        }
+    }
+    if !timings_ok {
+        return fail("submit_set_timings failed (could not open STAKING window)");
+    }
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+    // 6. Re-read the market — should now be approved with an open STAKING window.
+    let details = match dx.get_pmp_details(&pmp_address).await {
+        Ok(d) => d,
+        Err(e) => return fail(&format!("get_pmp_details after timings: {e:?}")),
+    };
+
+    let out = serde_json::json!({
+        "predictionMarketAddress": pmp_address,
+        "oracleAddress": oracle_address,
+        "oracleName": oracle_name,
+        // KEEP SECRET — the oracle key is needed to `submit_resolve` this market later.
+        "oracleSecretHex": oracle_keys.secret,
+        "eventId": event_id,
+        "tokenType": token_type,
+        "outcomes": outcome_list,
+        "approved": details.approved,
+        "oracleListHash": details.oracle_list_hash,
+        "stakeStart": details.stake_start,
+        "stakeEnd": details.stake_end,
+        "resultStart": details.result_start,
+        "resultEnd": details.result_end,
+        "endpoint": endpoint,
+    });
+    println!("{}", serde_json::to_string_pretty(&out).unwrap_or_else(|_| "{}".into()));
+    eprintln!("[dexdo create-prediction-market] DONE predictionMarketAddress={pmp_address} approved={}", details.approved);
+    ExitCode::SUCCESS
+}
+
 // ----------------------------- dispatch -----------------------------
 
 fn fail(msg: &str) -> ExitCode {
@@ -621,7 +906,13 @@ fn usage() -> String {
        withdraw      --pn-state-file <path> --dest 0:<multisig> [--dapp-id <id>]\n                  \
        Sweep the note's free collateral to a wallet (the multisig).\n  \
        pmp-details   --market-address 0:<pmp> [--endpoint host]\n                  \
-       Read a market's phase window, outcomes, and identity (read-only).\n\n\
+       Read a market's phase window, outcomes, and identity (read-only).\n  \
+       create-prediction-market  --pn-state-file <path> [--name <prefix>] \
+     [--outcomes \"A,B\"] [--stake-seconds N] [--endpoint host]\n                  \
+       Deploy a fresh oracle + event + PMP (one prediction market) using the funded \
+     deployer note, then open STAKING (oracle submitSetTimings). Prints \
+     predictionMarketAddress + oracleSecretHex (keep — needed to resolve) + windows. \
+     NOTE: the contract caps the STAKING window short (~90s), so stake promptly.\n\n\
      common flags:\n  \
        --endpoint    network host (default shellnet.ackinacki.org)\n"
         .to_string()
@@ -642,6 +933,7 @@ async fn dispatch(sub: &str, rest: &[String]) -> ExitCode {
         "claim" => cmd_claim(flags).await,
         "withdraw" => cmd_withdraw(flags).await,
         "pmp-details" => cmd_pmp_details(flags).await,
+        "create-prediction-market" => cmd_create_prediction_market(flags).await,
         other => fail(&format!("unknown subcommand `{other}`\n\n{}", usage())),
     }
 }


### PR DESCRIPTION
## What

`dexdo` gains the full **controllable prediction-market lifecycle** — create, resolve, then the existing stake/claim/withdraw — so a market can be driven end-to-end from the CLI without depending on the external e2e harness.

### `create-prediction-market`
Deploy a fresh oracle + event + PMP from a funded deployer note, then open the market (oracle `submitSetTimings`). The deployer note is auto-seeded with the initial stakes, so it already holds a position. Now also writes `<oracle>.oracle.keys.json` next to the note and prints `oraclePublicHex` + `oracleKeysFile` so the market can be resolved later.

- `--result-start <unix>` is the contract's own `resultStart` param (validated `>= now + MIN_RESULT_GAP` = 120s); the contract derives `stakeEnd = stakeStart + (resultStart-stakeStart)/10` and `resultEnd = resultStart + GRACE_PERIOD`.
- `--result-in <secs>` — relative convenience (resultStart = now-after-deploy + secs), so you control the resolve gap without guessing deploy duration.

### `submit-resolve` (new)
Resolve a market you hold the oracle key for: `PMP.submitResolve(outcomeId)` signed by the oracle key (quorum 1 → resolves immediately). Accepts `--oracle-keys <file {public,secret}>` or `--oracle-public/--oracle-secret`. Valid only in the resolve window `[resultStart, resultStart + GRACE_PERIOD]`.

## Verified end-to-end on shellnet
create → seeded stake (100+100 NACKL) → `submit-resolve` (RESOLVED, outcome 0) → `claim` → `withdraw` to the multisig. Note left flat, collateral swept. All SDK methods already existed (`deploy_oracle`, `add_event`, `deploy_pmp`, `submit_set_timings`, `submit_resolve`); this wires them into the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
