### PR TITLE
test(e2e): repin canonical SuperRoot address to 0:0c0c… (v4.0.15)

### DIFF
--- a/sdk/src/bin/onboard_user_shellnet.rs
+++ b/sdk/src/bin/onboard_user_shellnet.rs
@@ -126,6 +126,7 @@ enum NominalArg {
     N100,
     N1000,
     N10000,
+    N100000,
 }
 
 impl NominalArg {
@@ -134,7 +135,8 @@ impl NominalArg {
             "n100" | "100" => Ok(Self::N100),
             "n1000" | "1000" => Ok(Self::N1000),
             "n10000" | "10000" => Ok(Self::N10000),
-            other => Err(format!("unknown nominal `{other}` (use N100|N1000|N10000)")),
+            "n100000" | "100000" => Ok(Self::N100000),
+            other => Err(format!("unknown nominal `{other}` (use N100|N1000|N10000|N100000)")),
         }
     }
 
@@ -143,6 +145,7 @@ impl NominalArg {
             Self::N100 => 100,
             Self::N1000 => 1_000,
             Self::N10000 => 10_000,
+            Self::N100000 => 100_000,
         }
     }
 
@@ -155,6 +158,7 @@ impl NominalArg {
             Self::N100 => "N100",
             Self::N1000 => "N1000",
             Self::N10000 => "N10000",
+            Self::N100000 => "N100000",
         }
     }
 }

--- a/services/api/tests/common/airegistry.rs
+++ b/services/api/tests/common/airegistry.rs
@@ -68,7 +68,7 @@ const CREATION_SHELL: u64 = 200_000_000_000;
 /// `InferenceOrderBook` (`contracts/airegistry/InferenceOrderBook.sol`). A
 /// SuperRoot-code / RootModel rotation re-pins this; keep it in sync with the
 /// contract constant.
-const SUPER_ROOT_ADDR: &str = "0:36f863b22cf08df9d1d1e5669a603d282d4046077e00d234289b17343bd9eb71";
+const SUPER_ROOT_ADDR: &str = "0:0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c";
 
 /// Immutable deal config passed to the `TokenContract` constructor.
 pub struct TokenDeal {


### PR DESCRIPTION
## What
The airegistry e2e helper (`services/api/tests/common/airegistry.rs`) hardcoded the pre-v4.0.15 SuperRoot address `0:36f863b2…`. In v4.0.15 the contracts moved `SUPER_ROOT_ADDR` to the vanity `0:0c0c…0c` (see the constant in `PrivateNote.sol` / `TokenContract.sol` / `InferenceOrderBook.sol`).

Result on shellnet: `getRootModelAddress()` queried the stale, inactive account, so every inference e2e test failed with `AccountIsNotActive: 0:36f863b2… is not active`.

## Change
Repin the helper constant to the v4.0.15 address:
```
-0:36f863b22cf08df9d1d1e5669a603d282d4046077e00d234289b17343bd9eb71
+0:0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c
```
It is the only code reference to the old address (grep-verified); docs mention SuperRoot only conceptually, no hardcoded address.

## Notes
- Fixes the inference e2e failures **only if SuperRoot is actually deployed + Active at `0:0c0c…0c` on shellnet**.
- Market/order e2e failures are a separate matter (the S3 seed note must be a NACKL note — markets deploy in NACKL; a SHELL note reverts `deployPMP` with `ERR_LOW_VALUE`).