### PR TITLE
ci(e2e): self-provision seed note per run + drain in teardown

### DIFF
--- a/.github/workflows/e2e-shellnet.yml
+++ b/.github/workflows/e2e-shellnet.yml
@@ -65,19 +65,24 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@nextest
 
-      # The notes file carries real PN secret keys, so it is never committed.
-      # CI fetches it from the URL in the E2E_NOTES_URL secret and drops it at
-      # the path TestPnPool::load() reads (tests/fixtures/seed_notes.json).
-      - name: Fetch e2e seed notes
-        env:
-          E2E_NOTES_URL: ${{ secrets.E2E_NOTES_URL }}
+      # Self-provision a fresh throwaway deployer note per run, minted from the
+      # public shellnet giver (`mint_pn_pool` → `<out>.seed_notes.json`, the exact
+      # format TestPnPool::load() reads). Replaces the old S3 fetch: the suite
+      # shares one note (TestPnPool::first()), and once a run drains + withdraws
+      # it (the hasWithdrawn latch) that note is dead for deployPMP
+      # (ERR_INVALID_STATE), so any long-lived hosted note goes stale. A fresh
+      # note per run sidesteps cross-run poisoning and needs no secret. NACKL
+      # because markets deploy in NACKL; the note also gets SHELL gas, which
+      # covers the inference escrow. It is drained in the teardown step below.
+      - name: Mint fresh e2e seed note
+        working-directory: sdk
         run: |
-          if [ -z "$E2E_NOTES_URL" ]; then
-            echo "E2E_NOTES_URL secret is not set — add the seed-notes URL." >&2
-            exit 1
-          fi
-          curl -fsSL "$E2E_NOTES_URL" -o tests/fixtures/seed_notes.json
-          test -s tests/fixtures/seed_notes.json
+          cargo run --release --bin mint_pn_pool -- \
+            --count 1 --nominal N10000 --token-type nackl \
+            --endpoint https://shellnet.ackinacki.org \
+            --output "$RUNNER_TEMP/pn_pool.json"
+          cp "$RUNNER_TEMP/pn_pool.seed_notes.json" "$GITHUB_WORKSPACE/tests/fixtures/seed_notes.json"
+          test -s "$GITHUB_WORKSPACE/tests/fixtures/seed_notes.json"
 
       # Single-threaded on purpose: the PN-per-slot pool removes the per-PN
       # `_busy` contention, but every deploy still hits the shellnet-global
@@ -89,3 +94,23 @@ jobs:
       # long for CI. Run it locally on demand: drop the `-E` filter.
       - name: cargo nextest run (e2e, single-threaded)
         run: cargo nextest run -p dodex-api --run-ignored only --test-threads 1 --no-fail-fast -E 'not binary(e2e_inference_dispute)'
+
+      # Teardown: drain the throwaway note to a random (uninit) address so the
+      # plaintext key surfaced in the mint step / fixture controls no funds after
+      # the run — and the note ends in the hasWithdrawn state, unusable. Runs even
+      # if the suite failed; best-effort (the next run mints a fresh note anyway),
+      # so a drain failure never fails the job.
+      - name: Drain e2e seed note (teardown)
+        if: always()
+        working-directory: sdk
+        run: |
+          seed="$GITHUB_WORKSPACE/tests/fixtures/seed_notes.json"
+          [ -s "$seed" ] || { echo "no seed note to drain — skip"; exit 0; }
+          jq '{pn_address: .[0].pn_address, owner_public_key_hex: .[0].pn_pubkey_hex, owner_secret_key_hex: .[0].pn_seckey_hex}' \
+            "$seed" > "$RUNNER_TEMP/pn_state.json"
+          dest="0:$(openssl rand -hex 32)"
+          echo "draining seed note to random dest $dest"
+          cargo run --release --bin dexdo -- withdraw \
+            --pn-state-file "$RUNNER_TEMP/pn_state.json" \
+            --dest "$dest" \
+            --endpoint shellnet.ackinacki.org || echo "teardown withdraw failed (non-fatal)"

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -146,7 +146,8 @@ jobs:
 
   # Gated e2e: only after fmt/clippy, tests and openapi-drift are green.
   # Delegates to the reusable e2e-shellnet workflow (real shellnet,
-  # single-threaded). Needs the E2E_NOTES_URL secret.
+  # single-threaded). It self-provisions a fresh seed note per run
+  # (mint_pn_pool) and drains it in teardown — no secret needed.
   e2e:
     name: e2e (shellnet)
     needs: [fmt-clippy, tests, openapi-drift]

--- a/docs/seed-private-notes.md
+++ b/docs/seed-private-notes.md
@@ -138,14 +138,24 @@ a pool per consumer) so they never contend on the same PN on-chain:
 | --- | --- | --- |
 | local API dev (`cargo run` + `seed_accounts: true`) | `config/seed_notes_list.json` | drop locally |
 | local e2e (`cargo nextest … --run-ignored only`) | `tests/fixtures/seed_notes.json` | drop locally |
-| CI e2e | S3, fetched via the `E2E_NOTES_URL` secret | upload the slice; CI `curl`s it into `tests/fixtures/seed_notes.json` |
+| CI e2e | `tests/fixtures/seed_notes.json` | **self-provisioned per run** — no upload |
 
 The e2e slice needs **at least one funded note** (the suite shares a single
 deployer-PN — see [tests/fixtures/README.md](../tests/fixtures/README.md)),
 funded to cover every test's ~300 NACKL market deploy across the whole run.
 The `.seed_notes.json` sidecar is already in the right format — take the slice
-and place/upload it; all three files are secret (real keys) and git-ignored /
-never committed.
+and place it; both local files are secret (real keys) and git-ignored / never
+committed.
+
+CI e2e no longer pulls a hosted note. The
+[`e2e (shellnet)`](../.github/workflows/e2e-shellnet.yml) workflow **mints a
+fresh throwaway note per run** with `mint_pn_pool` (`--count 1 --nominal N10000
+--token-type nackl`) from the public giver, then **drains it to a random address
+in a teardown step** so the plaintext key printed in the run controls no funds
+afterwards. This sidesteps cross-run poisoning: the shared deployer note is
+withdrawn (or drained) during a run, and a withdrawn note is permanently dead
+for `deployPMP` (`ERR_INVALID_STATE`), so a long-lived hosted note would go
+stale. There is no `E2E_NOTES_URL` secret anymore.
 
 ## Tests
 

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -12,8 +12,10 @@ integration tests.
   secret keys for shellnet-only throwaway trading PNs, so it is never
   committed. `TestPnPool::load()` reads it from here (override the path
   with the `E2E_SEED_NOTES` env var). Provide it before an e2e run:
-  - **CI** fetches it from the `E2E_NOTES_URL` secret — see
-    [`.github/workflows/e2e-shellnet.yml`](../../.github/workflows/e2e-shellnet.yml).
+  - **CI** self-provisions it: the
+    [`e2e (shellnet)`](../../.github/workflows/e2e-shellnet.yml) workflow mints a
+    fresh throwaway note per run with `mint_pn_pool` and drains it to a random
+    address in a teardown step (no hosted note, no secret).
   - **Locally**, drop your own copy here. `mint_pn_pool` writes a
     `<output>.seed_notes.json` sidecar in exactly this format (run it with an
     `https://` endpoint, else its shellnet calls time out) — use that slice; see
@@ -104,9 +106,10 @@ test run and ages out on its own.
 
 Each deploy spends ~300 NACKL of collateral on the deployer-PN (2 × 100 NACKL
 initial stakes + 2 × 0.2 NACKL regular stakes + 100 NACKL split collateral).
-The notes in `seed_notes.json` must hold balances above that threshold; top
-them up via `mint_pn_pool` (`sdk/src/bin/mint_pn_pool.rs`) and refresh the S3
-copy when balances drop.
+The note in `seed_notes.json` must hold a balance above that threshold across
+the whole run. CI mints a fresh note per run (`mint_pn_pool`,
+`sdk/src/bin/mint_pn_pool.rs`); locally, top yours up the same way when it runs
+low.
 
 See the `SECURITY NOTE` block at the top of
 [`services/api/tests/e2e_order.rs`](../../services/api/tests/e2e_order.rs)


### PR DESCRIPTION
## Problem
The e2e suite shares **one** deployer note (`TestPnPool::first()`). Any run that withdraws/drains that note flips its `hasWithdrawn` latch, and a withdrawn note is **permanently dead** for `deployPMP` (`ERR_INVALID_STATE` / exit 151). So a long-lived note hosted in S3 (`E2E_NOTES_URL`) goes stale and every market test starts failing — exactly what we hit.

## Change
Stop hosting a note; **self-provision a fresh one per run and drain it after**:

- **Mint step** (replaces the S3 fetch): `mint_pn_pool --count 1 --nominal N10000 --token-type nackl` from the public giver writes `<out>.seed_notes.json` — the exact format `TestPnPool::load()` reads. NACKL because markets deploy in NACKL; the note also receives SHELL gas, which covers the inference escrow. No secret needed.
- **Teardown step** (`if: always()`): drain the note to a **random address** via `dexdo withdraw` so the plaintext key surfaced in the run controls no funds afterwards, and the note ends `hasWithdrawn`. Best-effort — a drain failure never fails the job; the next run mints anew.

Drops the `E2E_NOTES_URL` dependency. `docs/seed-private-notes.md`, `tests/fixtures/README.md`, and the `pr-tests.yml` comment updated to match.

## Notes / risks
- The e2e job now builds + runs the **sdk** workspace (`mint_pn_pool`, `dexdo`) — halo2/snark stack. First run is slower (SRS generation + cold build); watch against the 45-min `timeout-minutes`. May need cache tuning.
- The `E2E_NOTES_URL` repo secret is now unused and can be removed from settings.
- Existing inference/market fixes ride on PR #98 (SuperRoot address) — independent.