### PR TITLE
feat(dexdo): oracle range-event CLI for inference markets + skill

### DIFF
--- a/.claude/skills/dexdo-oracle-inference/SKILL.md
+++ b/.claude/skills/dexdo-oracle-inference/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: dexdo-oracle-inference
+description: Deploy a DEX.DO oracle on Acki Nacki Shellnet and bind it to an inference market — register a numeric RANGE event whose outcome is decided by an InferenceOrderBook's weekly-median reference price (spec §6.2). This is how an oracle "supports" inference markets: a prediction market resolves from a model's on-chain price. All on-chain via the dodex-sdk libraries (deploy_oracle + the dexdo CLI) — NO REST API. Load when the user wants to deploy an oracle for inference, make a prediction market resolve from an inference order book, add/resolve a range event, or wire an oracle to a model's weekly-median price.
+---
+
+# DEX.DO — Oracle for Inference Markets (Shellnet)
+
+Deploys an **Oracle** (+ its `OracleEventList`) and binds a **range event** to an
+**`InferenceOrderBook`**, so a prediction market's outcome is decided by that
+model's **weekly-median reference price** (spec §6.2 "range events").
+
+**Everything here is on-chain via the dodex-sdk libraries — no REST API.** The
+tools are the `deploy_oracle` and `dexdo` SDK binaries; the REST backend has no
+oracle endpoints and is never touched.
+
+## What an oracle has to do with inference
+
+Oracles belong to the **prediction-market** side (`RootOracle → Oracle →
+OracleEventList`). An inference market (`InferenceOrderBook` + `TokenContract`)
+does **not** use an oracle to run — it is a CLOB settled by probe-tick escrow.
+
+The link is one specific thing: a prediction market can be a **numeric range
+event** whose outcome is read from an inference model's price. The
+`OracleEventList` stores `bounds[]` + the bound `InferenceOrderBook` address
+(`ob`); at resolution it calls `InferenceOrderBook.requestWeeklyMedian(...)`, the
+book pushes its weekly VWAP median back via `onWeeklyMedian`, and the median is
+bucketed into an outcome. So the **inference market is the price source**, the
+oracle is the consumer. "Deploying an oracle for inference" = deploy the oracle,
+then `add-range-event` bound to the book.
+
+```
+deploy_oracle            → Oracle + OracleEventList@0 (+ oracle keypair)
+dexdo add-range-event    → range event on the list, bound to ob=<InferenceOrderBook>, bounds[], outcomes[]
+   (a PrivateNote deploys a PMP referencing this event; the oracle confirmEvents it — prediction-market flow)
+dexdo resolve-range      → after the deadline: pull the book's weekly median → onWeeklyMedian buckets it → PMP resolves
+```
+
+## Scope
+
+- **Network:** Shellnet (public testnet — `deploy_oracle` tops `RootOracle` up
+  from the public giver). Mainnet is out of scope (no public giver).
+- **In scope:** deploy an Oracle; register a range event bound to an
+  InferenceOrderBook; resolve it after the deadline.
+- **Out of scope:** deploying the inference market itself (the
+  `InferenceOrderBook` is an INPUT — deploy it from a note via
+  `deployInferenceOrderBook`, see the inference deposit/trading flows); deploying
+  the PMP/prediction market and staking/trading on it (that is the note owner's
+  side — `dexdo-trading`).
+
+## Inputs
+
+- **The InferenceOrderBook address** (`0:<hex>`) — the model's on-chain order
+  book whose weekly median resolves the event. Provided by the user (or found via
+  the inference market listing). This is the `--ob` argument.
+- **Range bounds + outcome labels** — the price buckets. `N` strictly-increasing
+  upper bounds (raw `uint256` price units, the same units the book quotes) yield
+  `N+1` outcomes; you supply `N+1` dense labels `0..N`.
+- **Deadline** — a unix timestamp; must be at least `MIN_RESULT_GAP` in the
+  future (it doubles as the PMP result-start).
+
+## Setup
+
+Uses the `deploy_oracle` and `dexdo` SDK binaries. Build once (release):
+
+```sh
+export WORKSPACE="${WORKSPACE:-$HOME/dexdo-workspace}"
+cd "$WORKSPACE/dexdo/sdk"
+cargo build --release --bin deploy_oracle --bin dexdo
+DEPLOY_ORACLE="$WORKSPACE/dexdo/sdk/target/release/deploy_oracle"
+DEXDO="$WORKSPACE/dexdo/sdk/target/release/dexdo"
+ENDPOINT="shellnet.ackinacki.org"
+```
+
+If the repo/workspace is not set up yet, do the clone + toolchain setup from
+`dexdo-deposit-shellnet` §Setup first (same `$WORKSPACE/dexdo`). `jq` is used
+below to parse the deploy output.
+
+## Step 1 — Deploy the oracle
+
+`deploy_oracle` generates a fresh oracle keypair, tops up `RootOracle` from the
+giver, calls `RootOracle.deployOracle`, and waits for the `Oracle` and its
+`OracleEventList@0` to go Active. It prints a JSON object on stdout:
+
+```sh
+mkdir -p "$WORKSPACE/oracle"
+"$DEPLOY_ORACLE" --endpoint "$ENDPOINT" --name-prefix dodex-oracle \
+  > "$WORKSPACE/oracle/oracle.json"
+cat "$WORKSPACE/oracle/oracle.json"
+# → { "address": "0:<oracle>", "pubkey_hex": "...", "secret_hex": "...<SECRET>",
+#     "event_list_address": "0:<OracleEventList@0>" }
+
+# Pull the pieces the next steps need.
+EVENT_LIST=$(jq -r .event_list_address "$WORKSPACE/oracle/oracle.json")
+ORACLE_PUB=$(jq -r .pubkey_hex        "$WORKSPACE/oracle/oracle.json")
+ORACLE_SEC=$(jq -r .secret_hex        "$WORKSPACE/oracle/oracle.json")
+chmod 600 "$WORKSPACE/oracle/oracle.json"
+echo "oracle EventList = $EVENT_LIST"
+```
+
+> **`oracle.json` holds the oracle SECRET key** (`secret_hex`) — it is what signs
+> `addRangeEvent` / `confirmEvent` / `resolveRange`. Keep it `0600`, never commit
+> it, never paste it into the chat. Back it up: losing it means the oracle can no
+> longer confirm or resolve its events.
+
+## Step 2 — Bind a range event to the inference order book
+
+Register the range event on the oracle's `OracleEventList`, pointing `--ob` at the
+model's `InferenceOrderBook`. Signed with the oracle keys from Step 1.
+
+```sh
+OB="0:<inferenceOrderBookAddress>"          # the model's book (input)
+DEADLINE=$(( $(date +%s) + 3600 ))          # unix; ≥ now + MIN_RESULT_GAP
+
+"$DEXDO" add-range-event \
+  --endpoint "$ENDPOINT" \
+  --event-list-address "$EVENT_LIST" \
+  --oracle-pubkey-hex "$ORACLE_PUB" \
+  --oracle-secret-hex "$ORACLE_SEC" \
+  --event-name "eth-weekly-median-$(date +%s)" \
+  --describe "ETH model weekly median band" \
+  --ob "$OB" \
+  --deadline "$DEADLINE" \
+  --bounds "1000000000,2000000000" \
+  --outcomes "below-1,1-to-2,above-2" \
+  --oracle-fee 0
+```
+
+Rules the contract enforces (get them right or the call reverts
+`ERR_INVALID_PARAMS`):
+
+- `--bounds` — comma-separated `uint256` **strictly increasing** upper bounds, in
+  the book's raw price units. `N` bounds.
+- `--outcomes` — comma-separated labels, **exactly `N+1`**, dense buckets `0..N`
+  (`< bound0`, `[bound0,bound1)`, …, `≥ boundN-1`). The CLI checks the count
+  before sending.
+- `--deadline` — unix seconds, at least `MIN_RESULT_GAP` ahead of now (it doubles
+  as the PMP result-start; a too-near deadline reverts).
+- `--oracle-fee` — raw fee amount (defaults to 0); `--describe` optional.
+
+On success the contract emits `RangeEventAdded(eventId, ob, bounds)`, where
+`eventId = hash(eventName, deadline, describe, outcomeNames)`. That `eventId` is
+what a `PrivateNote` uses when it `deployPMP`s the prediction market against this
+event, and what `resolve-range` needs later. Read it back (library-only) from the
+list's `_events` / `getRangeData` getters, or from the `RangeEventAdded` ext-out
+event; the read API surfaces it as the hex `eventId` on the oracle's events if you
+prefer to look it up there.
+
+Verify the binding landed:
+
+```sh
+tvm-cli -u "$ENDPOINT" run "${EVENT_LIST#0:}::${EVENT_LIST#0:}" getRangeData \
+  "{\"eventId\":\"<eventId>\"}" \
+  --abi "$WORKSPACE/dexdo/contracts/dex/OracleEventList.abi.json"
+# → bounds + ob == the InferenceOrderBook you bound
+```
+
+## Step 3 (later) — Resolve the range event
+
+After `--deadline`, anyone can trigger resolution; it pulls the book's weekly
+median (`requestWeeklyMedian → onWeeklyMedian`) and maps it into an outcome
+bucket, resolving the confirmed PMP. Sign with the oracle keys.
+
+```sh
+"$DEXDO" resolve-range \
+  --endpoint "$ENDPOINT" \
+  --event-list-address "$EVENT_LIST" \
+  --oracle-pubkey-hex "$ORACLE_PUB" \
+  --oracle-secret-hex "$ORACLE_SEC" \
+  --event-id "<eventId>" \
+  --oracle-list-hash "<oracleListHash>" \
+  --token-type 1
+```
+
+`--event-id`, `--oracle-list-hash`, and `--token-type` identify the **confirmed
+prediction market** (a PMP is `computePMPAddressFromHash(eventId, oracleListHash,
+tokenType)`): `eventId` from Step 2; `oracleListHash` and `tokenType` from the PMP
+that was deployed against this event (the note-owner / market side). The book
+needs enough weekly liquidity, else `_weeklyMedian()` reverts `ERR_NO_LIQUIDITY`.
+
+## The rest of the lifecycle (context, not this skill)
+
+For the market to actually exist and resolve, the prediction-market side must
+happen too — a `PrivateNote` deploys a PMP referencing this `eventId`, and the
+oracle `confirmEvent`s it (quorum), moving it from STAKING → TRADING → RESOLVING.
+Those steps are the note owner's / trader's flow (`dexdo-trading`,
+`dexdo-deposit-shellnet`); this skill only owns the oracle side: **deploy the
+oracle and bind/resolve the range event against the inference order book.**
+
+## What the user has after the skill
+
+- A deployed, Active `Oracle` + `OracleEventList` under their oracle keypair
+  (`$WORKSPACE/oracle/oracle.json`, secret — back it up).
+- A range event on that list bound to a chosen `InferenceOrderBook`, so a
+  prediction market deployed against its `eventId` resolves from the model's
+  weekly-median price — and the `resolve-range` call to settle it after the
+  deadline.

--- a/sdk/src/bin/dexdo.rs
+++ b/sdk/src/bin/dexdo.rs
@@ -28,11 +28,17 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::ExitCode;
+use std::sync::Arc;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
 use ackinacki_kit::tvm_client::abi::Signer;
 use ackinacki_kit::tvm_client::crypto::KeyPair;
+use ackinacki_kit::tvm_client::ClientConfig;
+use ackinacki_kit::tvm_client::ClientContext;
+use dodex_contracts::dex::oracle_event_list::OracleEventList;
+use dodex_contracts::dex::oracle_event_list::ParamsOfAddRangeEvent;
+use dodex_contracts::dex::oracle_event_list::ParamsOfResolveRange;
 use dodex_contracts::dex::private_note::ParamsOfCancelAllOrders;
 use dodex_contracts::dex::private_note::ParamsOfMergeFullSet;
 use dodex_contracts::dex::private_note::ParamsOfPlaceOrder;
@@ -40,6 +46,7 @@ use dodex_contracts::dex::private_note::ParamsOfSetStake;
 use dodex_contracts::dex::private_note::ParamsOfStakeKey;
 use dodex_contracts::dex::private_note::ParamsOfWithdrawTokens;
 use dodex_contracts::dex::pmp::ParamsOfSubmitResolve;
+use dodex_sdk::dex_contract_params;
 use dodex_sdk::Dex;
 use dodex_sdk::DexConfig;
 use serde::Deserialize;
@@ -96,6 +103,14 @@ impl Flags {
 fn dex(endpoint: &str) -> Result<Dex, String> {
     Dex::new(DexConfig { endpoints: vec![endpoint.to_string()], ..Default::default() })
         .map_err(|e| format!("cannot create Dex client: {e:?}"))
+}
+
+/// Raw tvm-client context for contracts the `Dex` facade does not wrap directly
+/// (the `OracleEventList` oracle-side ops). Library-only — no REST.
+fn tvm_context(endpoint: &str) -> Result<Arc<ClientContext>, String> {
+    let mut config = ClientConfig::default();
+    config.network.endpoints = Some(vec![endpoint.to_string()]);
+    ClientContext::new(config).map(Arc::new).map_err(|e| format!("cannot create tvm context: {e:?}"))
 }
 
 // ----------------------------- shared helpers -----------------------------
@@ -615,6 +630,83 @@ async fn cmd_resolve(f: Flags) -> ExitCode {
     }
 }
 
+/// `dexdo add-range-event` — register a numeric RANGE event on an
+/// `OracleEventList` whose outcome is decided by a bound `InferenceOrderBook`'s
+/// weekly-median price (spec §6.2). This is how an oracle "supports" an inference
+/// market: `--bounds` (strictly increasing upper bounds) bucket the median into
+/// one of N+1 outcomes labelled by `--outcomes`, and `resolve-range` (after
+/// `--deadline`) pulls the price via `requestWeeklyMedian → onWeeklyMedian`.
+/// Signed with the oracle owner keys (the `pubkey_hex`/`secret_hex` printed by
+/// `deploy_oracle`). Library-only — talks straight to the contract, no REST.
+async fn cmd_add_range_event(f: Flags) -> ExitCode {
+    let event_list = match f.require("event-list-address") { Ok(v) => v.to_string(), Err(e) => return fail(&e) };
+    let public = match f.require("oracle-pubkey-hex") { Ok(v) => v.to_string(), Err(e) => return fail(&e) };
+    let secret = match f.require("oracle-secret-hex") { Ok(v) => v.to_string(), Err(e) => return fail(&e) };
+    let event_name = match f.require("event-name") { Ok(v) => v.to_string(), Err(e) => return fail(&e) };
+    let ob = match f.require("ob") { Ok(v) => v.to_string(), Err(e) => return fail(&e) };
+    let describe = f.get("describe").unwrap_or("").to_string();
+    let oracle_fee: u128 = match f.get("oracle-fee").unwrap_or("0").parse() {
+        Ok(v) => v, Err(e) => return fail(&format!("--oracle-fee: {e}")),
+    };
+    let deadline: u64 = match f.require("deadline").and_then(|v| v.parse().map_err(|e| format!("--deadline: {e}"))) {
+        Ok(v) => v, Err(e) => return fail(&e),
+    };
+    let bounds: Vec<String> = match f.require("bounds") {
+        Ok(v) => v.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect(),
+        Err(e) => return fail(&e),
+    };
+    let labels: Vec<String> = match f.require("outcomes") {
+        Ok(v) => v.split(',').map(|s| s.trim().to_string()).collect(),
+        Err(e) => return fail(&e),
+    };
+    if bounds.is_empty() {
+        return fail("--bounds needs at least one upper bound (comma-separated, strictly increasing)");
+    }
+    if labels.len() != bounds.len() + 1 {
+        return fail(&format!(
+            "--outcomes must have bounds+1 = {} labels (got {}); labels are the dense 0..N buckets",
+            bounds.len() + 1, labels.len()
+        ));
+    }
+    let outcome_names: HashMap<u32, String> =
+        labels.into_iter().enumerate().map(|(i, s)| (i as u32, s)).collect();
+    let ctx = match tvm_context(&f.endpoint()) { Ok(c) => c, Err(e) => return fail(&e) };
+    let el = OracleEventList::new(ctx, dex_contract_params(&event_list));
+    eprintln!("[dexdo add-range-event] list {event_list} event '{event_name}' → ob {ob} bounds {bounds:?}");
+    match el.add_range_event(
+        ParamsOfAddRangeEvent { event_name, oracle_fee, deadline, describe, bounds, outcome_names, ob },
+        Signer::Keys { keys: KeyPair { public, secret } },
+    ).await {
+        Ok(r) => { println!("[dexdo add-range-event] DONE: {r:?}"); ExitCode::SUCCESS }
+        Err(e) => fail(&format!("add_range_event failed: {e:?}")),
+    }
+}
+
+/// `dexdo resolve-range` — after the event deadline, pull the bound
+/// `InferenceOrderBook`'s weekly median and resolve the range event (the median
+/// is mapped to an outcome bucket in the `onWeeklyMedian` callback). Callable by
+/// anyone; signed with the oracle owner keys. Library-only — no REST.
+async fn cmd_resolve_range(f: Flags) -> ExitCode {
+    let event_list = match f.require("event-list-address") { Ok(v) => v.to_string(), Err(e) => return fail(&e) };
+    let public = match f.require("oracle-pubkey-hex") { Ok(v) => v.to_string(), Err(e) => return fail(&e) };
+    let secret = match f.require("oracle-secret-hex") { Ok(v) => v.to_string(), Err(e) => return fail(&e) };
+    let event_id = match f.require("event-id") { Ok(v) => v.to_string(), Err(e) => return fail(&e) };
+    let oracle_list_hash = match f.require("oracle-list-hash") { Ok(v) => v.to_string(), Err(e) => return fail(&e) };
+    let token_type: u32 = match f.require("token-type").and_then(|v| v.parse().map_err(|e| format!("--token-type: {e}"))) {
+        Ok(v) => v, Err(e) => return fail(&e),
+    };
+    let ctx = match tvm_context(&f.endpoint()) { Ok(c) => c, Err(e) => return fail(&e) };
+    let el = OracleEventList::new(ctx, dex_contract_params(&event_list));
+    eprintln!("[dexdo resolve-range] list {event_list} event {event_id} (token {token_type})");
+    match el.resolve_range(
+        ParamsOfResolveRange { event_id, oracle_list_hash, token_type },
+        Signer::Keys { keys: KeyPair { public, secret } },
+    ).await {
+        Ok(r) => { println!("[dexdo resolve-range] DONE: {r:?}"); ExitCode::SUCCESS }
+        Err(e) => fail(&format!("resolve_range failed: {e:?}")),
+    }
+}
+
 // ----------------------------- dispatch -----------------------------
 
 fn fail(msg: &str) -> ExitCode {
@@ -645,7 +737,16 @@ fn usage() -> String {
        withdraw      --pn-state-file <path> --dest 0:<multisig> [--dapp-id <id>]\n                  \
        Sweep the note's free collateral to a wallet (the multisig).\n  \
        pmp-details   --market-address 0:<pmp> [--endpoint host]\n                  \
-       Read a market's phase window, outcomes, and identity (read-only).\n\n\
+       Read a market's phase window, outcomes, and identity (read-only).\n  \
+       add-range-event  --event-list-address 0:<el> --oracle-pubkey-hex <hex> \
+     --oracle-secret-hex <hex> --event-name <str> --ob 0:<inferenceOrderBook> \
+     --deadline <unix> --bounds <n1,n2,..> --outcomes <l0,l1,..> \
+     [--oracle-fee <raw>] [--describe <str>]\n                  \
+       Bind an oracle range event to an inference order book: its weekly-median \
+     price resolves the outcome (spec 6.2). Sign with the oracle keys from deploy_oracle.\n  \
+       resolve-range  --event-list-address 0:<el> --oracle-pubkey-hex <hex> \
+     --oracle-secret-hex <hex> --event-id <uint256> --oracle-list-hash <uint256> --token-type <id>\n                  \
+       After the deadline, pull the bound order book's weekly median and resolve the range event.\n\n\
      common flags:\n  \
        --endpoint    network host (default shellnet.ackinacki.org)\n"
         .to_string()
@@ -664,6 +765,8 @@ async fn dispatch(sub: &str, rest: &[String]) -> ExitCode {
         "cancel-stake" => cmd_cancel_stake(flags).await,
         "delete-stake" => stake_key_op(flags, "delete-stake").await,
         "resolve" => cmd_resolve(flags).await,
+        "add-range-event" => cmd_add_range_event(flags).await,
+        "resolve-range" => cmd_resolve_range(flags).await,
         "merge-full-set" => cmd_merge_full_set(flags).await,
         "claim" => cmd_claim(flags).await,
         "withdraw" => cmd_withdraw(flags).await,


### PR DESCRIPTION
## What
Adds the **oracle side** of binding a prediction market to an inference market (spec §6.2 "range events"), entirely through the **dodex-sdk libraries — no REST API**.

An inference market (`InferenceOrderBook`) doesn't use an oracle to run. The link is a **range event**: an `OracleEventList` stores `bounds[]` + a bound `InferenceOrderBook` (`ob`), and at resolution the book's **weekly-median price** is bucketed into an outcome that resolves the PMP. There was no CLI for this (only Rust wrappers used internally by `mint_ob_pool`), so a skill couldn't drive it.

## Changes
- **`dexdo add-range-event`** — register a range event on an `OracleEventList` bound to `--ob <InferenceOrderBook>` with `--bounds` (strictly increasing) / `--outcomes` (N+1 dense labels) / `--deadline`, signed with the oracle keys. Validates the label/bound count before sending.
- **`dexdo resolve-range`** — after the deadline, pull the book's weekly median and resolve (`requestWeeklyMedian → onWeeklyMedian`).
- Both talk straight to the `OracleEventList` contract via a raw tvm-client context (the `Dex` facade doesn't wrap the oracle-side ops). Wired into dispatch + `usage()`.
- **New skill `dexdo-oracle-inference`** — documents the full flow: `deploy_oracle` → `dexdo add-range-event` bound to an `InferenceOrderBook` → `dexdo resolve-range`.

## Notes
- `sdk` is its own Cargo workspace, not covered by the root `cargo fmt --all` / `clippy --workspace` — kept the diff minimal (no mass reformat); builds clean (`cargo build --release --bin dexdo`).
- The prediction-market lifecycle (a note deploys the PMP against the event, oracle `confirmEvent`, stake/trade) is the note-owner side (`dexdo-trading`) — out of scope here; this is oracle-only.