### PR TITLE
ops(alerts): alert on each indexer's last-push age, with no environment pinned into the rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ All notable changes to DEX.DO are recorded here. Entries are date-based, newest 
 
 **What an operator has to do.** Neither fix repairs rows already in `raw_events`: there is no automatic re-decode, and reprojection replays the `event_type` stored at ingest rather than decoding the body again. Phantom `inference_deals` rows have to be deleted by hand — they are the ones whose `ContractDeployed` arrived on 703, and they will not come back on their own, because the rows that seeded them are already marked processed and are therefore outside the reprojection window. Rows already stored with `event_type` NULL stay undecodable and stay unprunable.
 
+### Added
+
+- **A liveness alert for the indexer — `dodex-indexer-down`.** Every other rule in [`deploy/grafana/provisioning/alerting/dodex-indexer-alerts.yaml`](deploy/grafana/provisioning/alerting/dodex-indexer-alerts.yaml) reads a gauge the indexer exports and sets `noDataState: OK`, so a process that has stopped exporting silences all of them by construction — "no data" is not "over threshold". The new rule watches how long ago each indexer last pushed instead: >120s (four missed 30s pushes), measured over a six-hour window so the alert does not resolve itself as the outage lengthens, and falling back to `absent()` for an indexer that never started at all. It matters more than an ordinary liveness page — the gateway retains a short window of events, and anything it ages out while the indexer is down cannot be recovered by reprojection, which replays `raw_events` and cannot refetch what was never captured.
+
+  No new substitution to install: the rule names no environment and raises one alert per indexer that reports, so the same file works whether a Grafana sees one environment or several.
+
 ## [2026-08-27]
 
 ### Fixed

--- a/deploy/grafana/provisioning/alerting/dodex-indexer-alerts.yaml
+++ b/deploy/grafana/provisioning/alerting/dodex-indexer-alerts.yaml
@@ -13,9 +13,11 @@
 # Each rule = a query node (refId A, instant) + a math condition node (refId C).
 # Counter alerts use a __name__=~"...(_total)?" matcher so they fire whether or
 # not the OTel→Prometheus exporter appends _total. Thresholds mirror the Grafana
-# dashboard (deploy/grafana/dodex-indexer-dashboard.json). noDataState is OK so a
-# fully-down indexer (series gone) does not flap these — pair with a separate
-# `up == 0` liveness alert for that case.
+# dashboard (deploy/grafana/dodex-indexer-dashboard.json). noDataState is OK on
+# every gauge/counter rule, so a fully-down indexer (series gone) does not flap
+# them — that case is covered by `dodex-indexer-down` below, which watches how
+# long ago the indexer last pushed rather than any threshold it reports.
+
 
 apiVersion: 1
 
@@ -25,6 +27,78 @@ groups:
     folder: Dodex Indexer
     interval: 1m
     rules:
+      # LIVENESS. Every other rule here reads a gauge the indexer exports and
+      # sets noDataState: OK, so a process that has stopped exporting silences
+      # all of them by construction — "no data" is not "over threshold". That is
+      # the outage most worth paging on: the gateway retains a short window of
+      # events, and anything it ages out while the indexer is down cannot be
+      # recovered by reprojection, which replays `raw_events` and cannot refetch
+      # what was never captured. A stall is permanent data loss, not a delay.
+      #
+      # NOT `up == 0`. The indexer is not a scrape target: it has no /metrics
+      # route and pushes OTLP to a collector (`OTEL_EXPORTER_OTLP_ENDPOINT`,
+      # PeriodicReader, 30s). Prometheus synthesises `up` for targets it scrapes,
+      # so `up{job="…"}` for the indexer does not exist and a rule built on it
+      # would alert on nothing at all — or, with noDataState: Alerting, forever.
+      #
+      # No environment selector, deliberately. `service.name` (and with it the
+      # `job` label) differs per environment — `dexdo-indexer` on prod,
+      # `dodex-indexer` on stage, set from `dexdo_otel_service_name` in the deploy
+      # inventory. Naming one of them here would need a copy of this rule per
+      # environment AND knowledge of whether each Grafana sees one or both, since
+      # a rule naming an environment its Grafana cannot see fires forever. The
+      # first half below is per-series instead: it produces one alert instance per
+      # `job` that actually reports, and none for a `job` that does not exist
+      # here. One rule, any topology, nothing to substitute.
+      #
+      # Why the subquery. `timestamp()` alone reads the last sample only while the
+      # series is inside Prometheus's lookback (~5min); past that the series is
+      # gone and the alert would resolve itself exactly as the outage got worse.
+      # `max_over_time(timestamp(...)[6h:1m])` is the last-seen timestamp over six
+      # hours, so the alert keeps firing through a long outage. 120s is four
+      # missed pushes at the 30s OTLP interval, with room for the 1m subquery
+      # resolution; detection lands around 3-4min with `for: 2m`.
+      #
+      # `absent()` is the second half and carries NO job selector on purpose: it
+      # covers the case the first half cannot see — an indexer that never started,
+      # so there is no series to have a timestamp. Unselectored it means "no
+      # indexer anywhere is reporting", which is correct in both topologies and
+      # cannot false-fire in either.
+      #
+      # noDataState is OK, not Alerting: in the HEALTHY case this expression
+      # matches nothing, so "no data" is the good state here.
+      - uid: dodex-indexer-down
+        title: Indexer not running
+        condition: C
+        for: 2m
+        noDataState: OK
+        execErrState: Error
+        labels: { severity: critical, service: dodex-indexer }
+        annotations:
+          summary: "Indexer not running"
+          description: "{{ $labels.job }} has not pushed metrics for over 120s (instance {{ $labels.instance }}), or no indexer series exists at all. Ingest has stopped, and events the gateway ages out meanwhile cannot be recovered by reprojection — it replays raw_events and cannot refetch. Restart it, then watch indexer_capture_cursor_age_seconds drain back to normal."
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: REPLACE_WITH_PROMETHEUS_DS_UID
+            model:
+              refId: A
+              editorMode: code
+              expr: (time() - max_over_time(timestamp(indexer_capture_cursor_age_seconds)[6h:1m]) > 120) or absent(indexer_capture_cursor_age_seconds)
+              instant: true
+              range: false
+              intervalMs: 1000
+              maxDataPoints: 43200
+              datasource: { type: prometheus, uid: REPLACE_WITH_PROMETHEUS_DS_UID }
+          - refId: C
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: math
+              expression: "$A > 0"
+              datasource: { type: __expr__, uid: __expr__ }
+
       - uid: dodex-proj-lag-warn
         title: Indexer projection lag elevated
         condition: C

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -486,7 +486,7 @@ The repository ships a ready dashboard and alert rules under `deploy/grafana/`:
 | File | What it is | How to use |
 | --- | --- | --- |
 | [`deploy/grafana/dodex-indexer-dashboard.json`](../deploy/grafana/dodex-indexer-dashboard.json) | Grafana dashboard covering every indexer metric — ingestion (`raw_events` counters), projection pipeline (backlog/lag/cursor age/fallbacks), DB pool, and inference markets (state, order depth, reconcile failures, price/sweep staleness) | Grafana → Dashboards → Import → Upload JSON; pick your Prometheus when prompted |
-| [`deploy/grafana/provisioning/alerting/dodex-indexer-alerts.yaml`](../deploy/grafana/provisioning/alerting/dodex-indexer-alerts.yaml) | 12 Grafana-managed alert rules (projection/cursor lag, decode errors, inference markets `failing`, reference-price & sweep staleness), warning→critical | Copy to Grafana's `/etc/grafana/provisioning/alerting/` and restart Grafana |
+| [`deploy/grafana/provisioning/alerting/dodex-indexer-alerts.yaml`](../deploy/grafana/provisioning/alerting/dodex-indexer-alerts.yaml) | 18 Grafana-managed alert rules: indexer liveness (last-push age), projection/cursor lag, decode errors, inference markets `failing`, reference-price & sweep staleness — warning→critical | Copy to Grafana's `/etc/grafana/provisioning/alerting/` and restart Grafana |
 
 Two setup notes, also documented in the files themselves:
 
@@ -495,13 +495,28 @@ Two setup notes, also documented in the files themselves:
   `counter_suffix` template variable (default `_total`; switch to `(none)` if your
   collector disables it); the alert rules match `…(_total)?` so they fire either
   way. Gauge metrics get no suffix.
-- **Alert data source UID.** Provisioned alert rules reference the Prometheus data
-  source by UID. Before installing, replace the placeholder with yours (found
-  under Connections → Data sources):
+- **Alert data source UID.** Provisioned alert rules reference the Prometheus
+  data source by UID. Replace the placeholder before installing:
   ```sh
   sed -i 's/REPLACE_WITH_PROMETHEUS_DS_UID/<your-uid>/g' \
     deploy/grafana/provisioning/alerting/dodex-indexer-alerts.yaml
   ```
+  That is the only substitution. The liveness rule deliberately names no
+  environment: `service.name` (and with it the `job` label) differs per
+  environment — it comes from `dexdo_otel_service_name` in the deploy inventory —
+  and pinning one would need a copy of the rule per environment plus knowledge of
+  which environments each Grafana can see. The rule is per-series instead, so it
+  raises one alert per indexer that actually reports and stays silent about ones
+  that do not exist wherever it is installed.
+- **Liveness is not optional.** `dodex-indexer-down` is the only rule that fires
+  when the indexer stops exporting. Every other rule sets `noDataState: OK`, so a
+  dead process silences them by construction. It watches how long ago each indexer
+  last pushed (>120s = four missed 30s pushes) over a six-hour window, so the
+  alert does not resolve itself as the outage lengthens, and falls back to
+  `absent()` for an indexer that never started at all. Events the gateway ages out
+  while the indexer is down cannot be recovered by reprojection, so this is the
+  rule that separates "we lost a few minutes of ingest" from "we lost it and
+  nobody noticed".
 
 Alert thresholds (lag/age cutoffs, `failing > 0`, decode-error rate) mirror the
 dashboard's panel thresholds and are conservative starting points — retune them


### PR DESCRIPTION
Adds the one alert this file has been asking for since it was written. Its own header said so:

> noDataState is OK so a fully-down indexer (series gone) does not flap these — pair with a separate `up == 0` liveness alert for that case.

That rule was never shipped, so the gap stayed open: **every** other rule here reads a gauge the indexer exports and sets `noDataState: OK`, which means a process that has stopped exporting silences all seventeen of them by construction. "No data" is not "over threshold". The alerts covering a stalled indexer are, by design, exactly the alerts that cannot fire when it is not running.

That matters more than an ordinary liveness page. The gateway retains only a short window of events, and anything it ages out while the indexer is down cannot be recovered: reprojection replays `raw_events`, it cannot refetch what was never captured. Downtime is permanent data loss, not a delay. Measured against mainnet while diagnosing something else: querying `blockchain.events` from a cursor at 2026-08-01 returned exactly one edge, the same one a cursor at 2026-08-30 returned. Whatever the retention window is, it is short enough that an unnoticed outage is unrecoverable.

---

## Not `up == 0`

The header's suggestion is the obvious rule, and it would not have worked here. The indexer is not a scrape target:

| Checked | Result |
|---|---|
| `scrape_configs` / `job_name` anywhere in the repo | none |
| `/metrics` route in `crates/` or `services/` | none |
| How metrics leave the process | `PeriodicReader` + OTLP `MetricExporter`, 30s (`crates/metrics/src/lib.rs`) |
| When metrics are exported at all | only when `OTEL_EXPORTER_OTLP_ENDPOINT` is set |

Prometheus synthesises `up` for targets **it scrapes**. The indexer only pushes, so `up{job="…"}` for it does not exist — a rule built on it would either alert on nothing at all, or, with `noDataState: Alerting`, fire forever. Credit to the rewards team for catching this before it shipped; the first draft of this branch had exactly that bug.

## What it does instead

```promql
(time() - max_over_time(timestamp(indexer_capture_cursor_age_seconds)[6h:1m]) > 120)
  or absent(indexer_capture_cursor_age_seconds)
```

The first half is "how long since this indexer last pushed". 120s is four missed pushes at the 30s `OTLP_READER_INTERVAL`, with room for the subquery's 1m resolution; with `for: 2m` detection lands around 3–4 minutes.

The subquery is what makes it survive the outage it is reporting. `timestamp()` alone reads the last sample only while the series is inside Prometheus's lookback (~5min); past that the series is gone, the expression empties, and the alert resolves itself exactly as things get worse. `max_over_time(timestamp(…)[6h:1m])` is the last-seen timestamp over six hours, so it keeps firing.

`absent()` is the second half and carries **no** job selector on purpose. It covers the one case the first half structurally cannot see — an indexer that never started, so there is no series to have a timestamp at all.

The gauge is a good liveness witness specifically because it is an `ObservableGauge` over an `AtomicU64` cache: the callback fires on every collection regardless of whether the refresh loop behind it is healthy. So the series' presence means "process alive and OTLP flowing", and its *value* remains a separate signal with its own two alerts.

`noDataState: OK`, which inverts the instinct: in the healthy case this expression matches nothing, so "no data" is the good state here. It is the reason the rule reads backwards from every other one in the file, and worth a second look during review.

## No environment is pinned into it, and that is the point

`service.name` — and with it the `job` label — differs per environment: `dexdo-indexer` on prod, `dodex-indexer` on stage, both set from `dexdo_otel_service_name` in the deploy inventory (the role default, `dodex-indexer-test`, belongs to the e2e environment, which exports nothing because `dexdo_otel_endpoint` is empty there).

Naming one of them would have meant a copy of this rule per environment **plus** knowing which environments each Grafana can see — because `absent()` with a job selector is a global "nothing matched", so a rule naming an environment its Grafana cannot see fires forever. That topology question is still open with devops, and this rule no longer waits on it: the first half is per-series, so it raises one alert instance per `job` that actually reports and stays silent about ones that do not exist wherever it is installed. One rule, either topology, nothing to substitute beyond the data-source UID every other rule here already needs.

## Scope

No code, no new metric — the rule reads a gauge that already exists. Docs and changelog updated; `docs/deployment.md` also had a stale rule count (12, actually 17 before this) which is now 18.

Rebased onto `dev` after #154 merged; the only conflict was the shared `## [2026-09-01]` changelog heading, resolved by keeping both sections under one date.

**Not verified against a live Grafana** — I have no instance to provision into. The YAML parses and the rule mirrors the structure of the seventeen shipped rules exactly (query node `A` + math condition `C`), but the PromQL itself has only been reasoned about, not executed. Worth an instant-query sanity check against real data before relying on it, starting with `count by (job) (indexer_capture_cursor_age_seconds)` to confirm which label the collector actually emits.
