### PR TITLE
docs(skills): repair the indexer DB runbook and widen it to prod, read-only

### DIFF
--- a/.claude/skills/indexer-db-diag/SKILL.md
+++ b/.claude/skills/indexer-db-diag/SKILL.md
@@ -1,24 +1,36 @@
 ---
-name: staging-diag
-description: Use when the staging deployment (Supabase Postgres) misbehaves — projection lag or sweep lag is growing, a market or oracle event that exists on-chain is missing from the API/read model, raw_events is bloating disk, or the indexer backlog will not drain.
+name: indexer-db-diag
+description: Use when a dodex indexer database misbehaves, on stage OR prod — projection lag or sweep lag is growing, a market or oracle event that exists on-chain is missing from the API/read model, raw_events is bloating disk, undecodable rows appear, or the indexer backlog will not drain.
 ---
 
-# Staging DB Diagnosis
+# Indexer DB Diagnosis
 
-Diagnose stage top-down: L1 ingest → L2 projection → L3 visibility. Each level's query is the same one the indexer's own metrics use (`crates/infrastructure/src/indexer_repo.rs`), so results match the dashboards.
+Diagnose top-down: L1 ingest → L2 projection → L3 visibility. Each level's query is the same one the indexer's own metrics use (`crates/infrastructure/src/indexer_repo.rs`), so results match the dashboards.
 
-## Connection — never paste secrets
+Both environments run the same migrations and the same schema, so **every query below is identical on stage and prod**. What differs is what the numbers MEAN — see [Reading the numbers per environment](#reading-the-numbers-per-environment). Ignoring that section is how a normal prod reads as an outage and a real one reads as normal.
 
-Read the URL from `~/.config/dodex/stage.env` (var `STAGE_DATABASE_URL`). If the file is missing, ask the user to create it (mode 600) — never paste a password into the chat or transcript. URL template: `docs/deployment.md` (Supabase section, ~line 106): `postgresql://<role>.<project-ref>:<password>@aws-...pooler.supabase.com:5432/postgres`, password percent-encoded (`$`→`%24`, `@`→`%40`).
+## Environment — pick one deliberately
+
+| | stage | prod |
+|---|---|---|
+| Credentials | `~/.config/dodex/stage.env` → `STAGE_DATABASE_URL` | `~/.config/dodex/prod.env` → `PROD_DATABASE_URL` |
+| Chain | shellnet | mainnet |
+| Writes | allowed after confirming with the user | **never — read-only, no exceptions** |
+
+**Default to stage.** Only touch prod when the user names it, and say which one you are on in your first reply — a number reported without its environment is worse than no number.
+
+**Prod is read-only.** Run `select` only. The Remediation section at the end does not apply to prod: `call prune_raw_events(...)` and `vacuum` are real operations against live data, and nothing in a diagnosis needs them. If prod turns out to need a mutation, hand the statement to the user rather than running it.
+
+If the env file is missing, ask the user to create it (mode 600) — never paste a password into the chat or transcript. URL template: `docs/deployment.md` (Supabase section, ~line 106): `postgresql://<role>.<project-ref>:<password>@aws-...pooler.supabase.com:5432/postgres`, password percent-encoded (`$`→`%24`, `@`→`%40`).
 
 ```bash
-set -a; . ~/.config/dodex/stage.env; set +a
+set -a; . ~/.config/dodex/stage.env; set +a      # or prod.env → PROD_DATABASE_URL
 PGCONNECT_TIMEOUT=8 psql "$STAGE_DATABASE_URL"
 ```
 
 The URL as a psql argument is visible in the host process list — acceptable on a single-user machine; otherwise use `~/.pgpass` or a `PGSERVICE` entry.
 
-Repo docs and the stage config use the pooler host on port **5432** (session mode) — use that for interactive psql. `sslmode=require` is the Supabase default (general Supabase behaviour; not in repo docs).
+Both indexer configs (`config/indexer.stage.supabase.yaml`, `~/.config/dodex/indexer.prod.yaml`) use the pooler host on port **5432** (session mode) — use that for interactive psql. `sslmode=require` is the Supabase default (general Supabase behaviour; not in repo docs).
 
 Session mode has 15 slots and they do run out, including through no fault of yours — a running indexer holds some. The symptom is `FATAL: (EMAXCONNSESSION) max clients reached in session mode - max clients are limited to pool_size: 15`. Port **6543** is the transaction pooler and has its own budget, so rewrite the port rather than waiting:
 
@@ -28,6 +40,23 @@ PGCONNECT_TIMEOUT=10 psql "$TX" -c '...'
 ```
 
 Transaction mode does not keep session state (no `SET`, no advisory locks held across statements), which none of the queries below need.
+
+## Reading the numbers per environment
+
+The queries are identical; these four readings are not. Each is a case where the honest answer on one environment is an incident on the other.
+
+| Reading | stage | prod |
+|---|---|---|
+| Old `ingest_age` | suspicious — e2e drives near-constant traffic | **normal** — mainnet is nearly idle |
+| `markets` empty | broken — prediction markets live here | **normal** — none are deployed to mainnet |
+| `undecodable > 0` | drift, act on it | check the DATE first, see below |
+| Remediation section | applies | **does not apply** |
+
+**Chain liveness.** Mainnet DEX-dapp activity is close to zero: a gateway query from a 2026-08-01 cursor returned a single event. So on prod an `ingest_age` of days means the chain is quiet, not that ingest died — the discriminator is `cursor_age`, which must stay fresh regardless of whether anything is arriving. On stage the two move together, so a quiet `ingest_age` there is worth chasing.
+
+**Undecodable on prod carries an immovable historical population.** The L2 rule below — any undecodable row means drift — is about rows arriving *now*. Prod also holds 31085 rows on dst 101 (`RootPN.PrivateNoteDeployed`), every one ingested on 2026-08-20 by the initial backfill, carrying a signature id from an older contract generation. The same id decodes cleanly on stage, so this is not a loaded-ABI problem; those bodies simply predate the current ABI and there is no re-decode path, so they will never resolve, never project and never become prunable. Judge prod drift by `max(created_at)` and by date buckets, never by the total.
+
+**Environments do not run the same build.** A fix merged to `dev` deploys to stage; prod deploys from `main` (`.woodpecker/deploy.yml`). Before concluding that prod behaves differently *by nature*, check whether it simply has an older binary — the decoder's loaded-ABI set is compiled in, so a decode difference between environments is usually a deploy difference.
 
 ## L1 — Is the indexer receiving events?
 
@@ -62,9 +91,9 @@ select count(*) as undecodable, max(created_at) as latest from raw_events where 
 
 Interpretation: backlog growing with old `oldest_pending` = projection loop stuck/slow — check indexer logs at the `min(chain_order)` row.
 
-**Any undecodable row means ABI drift — there is no benign background.** Every contract that emits to a scoped `dst` has its ABI loaded into the decoder (`DEX_ABIS` + `INFERENCE_ABIS`, twelve of them, `RootModel` and `SuperRoot` included). Of the ABIs that ship unloaded, `ModelRegistry` declares no events at all and `Multisig` is a wallet outside the ingest scope, so neither can put a row here. A non-zero count therefore means the decoder no longer matches the deployed contracts: rebuild and redeploy.
+**Any undecodable row arriving NOW means ABI drift — there is no benign background.** (On prod, read this together with the historical-backfill caveat above: judge by date, not by total.) Every contract that emits to a scoped `dst` has its ABI loaded into the decoder (`DEX_ABIS` + `INFERENCE_ABIS`, twelve of them, `RootModel` and `SuperRoot` included). Of the ABIs that ship unloaded, `ModelRegistry` declares no events at all and `Multisig` is a wallet outside the ingest scope, so neither can put a row here. A non-zero count therefore means the decoder no longer matches the deployed contracts: rebuild and redeploy.
 
-This is a recent sharpening. Until the registry ABIs were loaded, most undecodable rows were ordinary `RootModel`/`SuperRoot` events and a steady background WAS normal — on stage it was the entire undecodable population, 1058 rows. Text written against that era reads a flat count as harmless; it no longer is.
+This is a recent sharpening. Until the registry ABIs were loaded, most undecodable rows were ordinary `RootModel`/`SuperRoot` events and a steady background WAS normal — on stage they were the entire undecodable population, 1058 rows. Text written against that era reads a flat count as harmless; it no longer is.
 
 Undecodable rows are also never projected, never counted in the backlog above, and — because `processed_at` stays NULL forever — permanently out of the pruner's reach. Identify the contract before reporting a count:
 
@@ -161,9 +190,9 @@ select pg_size_pretty(pg_total_relation_size('raw_events')) as total,
   from raw_events;
 ```
 
-Interpretation. **Step 1 returning zero rows means the pruner is not installed** — no job can be running, whatever `cron` would have said. That is the state stage was found in on 2026-09-02, with 16330 rows already eligible; the fix is to apply `deploy/sql/prune_raw_events.sql` — which installs the procedure *and* schedules the job — not to hunt for a broken schedule. It has to run as a privileged role (on Supabase, the SQL editor, which runs as `postgres`); the pooler role can neither create the extension nor schedule jobs. See [`docs/deployment.md`](../../../docs/deployment.md) § raw_events retention. `permission denied for schema cron` in step 2 means "cannot check from here", **not** "the job is missing" — confirm through the Supabase dashboard (Database → Cron) or a privileged role. A `prunable_now` that keeps climbing across days is the outcome-level symptom either way.
+Interpretation. **Step 1 returning zero rows means the pruner is not installed** — no job can be running, whatever `cron` would have said. That is the state BOTH environments were found in on 2026-09-02 — no `prune_raw_events` in `pg_proc` on either, with 16330 rows already eligible on stage; the fix is to apply `deploy/sql/prune_raw_events.sql` — which installs the procedure *and* schedules the job — not to hunt for a broken schedule. It has to run as a privileged role (on Supabase, the SQL editor, which runs as `postgres`); the pooler role can neither create the extension nor schedule jobs. See [`docs/deployment.md`](../../../docs/deployment.md) § raw_events retention. `permission denied for schema cron` in step 2 means "cannot check from here", **not** "the job is missing" — confirm through the Supabase dashboard (Database → Cron) or a privileged role. A `prunable_now` that keeps climbing across days is the outcome-level symptom either way.
 
-**Remediation — mutates data, confirm with the user first** (out of scope for pure diagnosis):
+**Remediation — STAGE ONLY, mutates data, confirm with the user first** (out of scope for pure diagnosis). On prod, hand these to the user instead of running them:
 
 ```sql
 call public.prune_raw_events(interval '3 days', 10000);  -- only if step 1 found it
@@ -179,7 +208,7 @@ vacuum (analyze) raw_events;                              -- after a big purge
 | Ordering by `id`/`created_at` | `chain_order` (lex-sortable text) is the sole projection-ordering key. |
 | Judging visibility by `approved` | Read API gates on `last_reconciled_at IS NOT NULL` (`markets` and `inference_markets`). |
 | Counting inference books without `superseded_at IS NULL` | Superseded books are excluded from the API and metrics. |
-| "Ingest is broken — no `OrderBook.Queued` / `PMP.StakeAccepted` rows" | Stage drops those types before insert (`config/indexer.stage.supabase.yaml` `ignored_event_types`). |
+| "Ingest is broken — no `OrderBook.Queued` / `PMP.StakeAccepted` rows" | Both environments drop those three types before insert — `ignored_event_types` is byte-identical in `config/indexer.stage.supabase.yaml`, `~/.config/dodex/indexer.prod.yaml` and the ansible template. The list is an allow-list validated at startup, so it cannot grow through a config-only deploy. |
 | "There is no dapp filtering, `indexer.dapp_id` is unset" | The config key is indeed unset, but scoping is not done there: the gateway query itself is parameterised by `src_dapp_id` and pinned to the compile-time `DEX_DAPP_ID`, so ingest is dapp-scoped server-side, at fetch. What the unset key means is only that no *additional* local filter runs. |
 | Reading a flat `undecodable` count as harmless background | No longer true since the registry ABIs were loaded: nothing that reaches a scoped `dst` is undecodable by design any more, so any row there is drift. |
 | `permission denied for schema cron` = "the job is missing" | It means the role cannot look. Check `pg_proc` for the procedure first — that IS readable, and its absence is the answer the `cron` query was being asked for. |

--- a/.claude/skills/indexer-db-diag/SKILL.md
+++ b/.claude/skills/indexer-db-diag/SKILL.md
@@ -143,7 +143,36 @@ select now() - min(m.last_swept_at) as sweep_lag_actionable, count(*) as books_d
 
 Worked example (stage, 2026-09-02): raw `sweep_lag` read **5 days**, and 316 of 522 books had not been swept since the post-wipe catch-up on 08-28 — which looks like a mass stall. Every one of those 316 had **zero** open orders, while the 79 books swept within 20h held 10 between them. `sweep_lag_actionable` over the 10 books actually due: **2m17s**.
 
-Only after that reads badly is the gate worth checking: a sweep also waits on `at_head = true` and on no pending `raw_events` for the book's `src_address`, so an L2 backlog *can* stall it. Do not assume that link either — join the stale books against pending rows for the same `src_address` and measure. Recorded negative result: on an earlier stage dataset 2732 of 2901 books stale for over 7 days had no pending rows at all.
+**When `sweep_lag_actionable` is NULL it says nothing about liveness — read the two lags against each other instead.** With `books_due = 0` the actionable query returns NULL, which is the right answer to "how stale are the books due a sweep" and no answer at all to "is the reconciler running". The pair does answer it, because Queue B's candidate predicate is an OR of two independent due-conditions (`select_refresh_books_scoped`, `inference_reconciler.rs`):
+
+```
+(reference_price_at is null or reference_price_at < now() - reference_price_refresh)
+or
+((last_swept_at is null or last_swept_at < now() - sweep_interval)
+   and exists (select 1 from inference_orders o where ... o.status = 'OPEN'))
+```
+
+The `OPEN`-order gate hangs on the sweep half **only**. An idle book is therefore still visited on the price half, at the `reference_price_refresh` interval — it simply leaves `last_swept_at` untouched. So the two lags moving differently is itself the signal:
+
+| `price_lag` | `sweep_lag` | Reading |
+|---|---|---|
+| advancing — `min` moves forward | grows by exactly the elapsed time | loop alive, sweep idle by design |
+| grows by exactly the elapsed time | grows by exactly the elapsed time | Queue B is not turning — suspect the reconciler, not the data |
+
+Both numbers are `now() - min(...)`, so both grow on their own: take two readings minutes apart, or read the timestamps absolutely, and compare the growth against the wall-clock gap between them. Measured on prod, 2026-09-02, two readings ~1h36m apart: `sweep_lag` grew by the full 1h36m while `price_lag` grew by 9m35s. In absolute terms all 8 books carried a `reference_price_at` from the past hour, while `last_swept_at` spanned 08-25 to 08-31. Prod had zero `OPEN` orders anywhere, so `sweep_lag_actionable` was NULL and this pair was the only liveness evidence available.
+
+**`price_lag` carries the same latent flaw `sweep_lag` does.** The shipped metric (`inference_staleness_seconds`, `indexer_repo.rs`) takes `min(reference_price_at)` over `last_reconciled_at is not null` and does **not** exclude superseded books, while the refresh candidate query does — so a superseded book's price timestamp freezes and pins the metric upward for good. Check before believing a large `price_lag`:
+
+```sql
+select now() - min(reference_price_at) as price_lag_metric,
+       now() - min(reference_price_at) filter (where superseded_at is null) as price_lag_live,
+       count(*) filter (where superseded_at is not null) as superseded
+  from inference_markets where last_reconciled_at is not null;
+```
+
+Both environments held zero superseded books on 2026-09-02, so this one is structural — read off the two queries, not measured in the wild.
+
+Only after `sweep_lag_actionable` itself reads badly is the gate worth checking: a sweep also waits on `at_head = true` and on no pending `raw_events` for the book's `src_address`, so an L2 backlog *can* stall it. Do not assume that link either — join the stale books against pending rows for the same `src_address` and measure. Recorded negative result: on an earlier stage dataset 2732 of 2901 books stale for over 7 days had no pending rows at all.
 
 ## L3 — Why is market X not visible?
 
@@ -226,4 +255,6 @@ vacuum (analyze) raw_events;                              -- after a big purge
 | `permission denied for schema cron` = "the job is missing" | It means the role cannot look. Check `pg_proc` for the procedure first — that IS readable, and its absence is the answer the `cron` query was being asked for. |
 | Matching a `dst` by suffix (`like '%2bf'`) | `dst_address` holds both routing ids and ordinary 64-hex contract addresses; a suffix match catches addresses that merely end the same way. Compare the full `':' \|\| lpad(to_hex(id),64,'0')`, or extract with `right(dst_address,16)`. |
 | Reading `sweep_lag` (`min(last_swept_at)`) as sweep health | It includes books with no `OPEN` orders, which are never re-swept by design, so it only ever grows. Measure over books that have an open order — on stage that was 5 days versus 2m17s for the same database. |
+| `sweep_lag_actionable` came back NULL, so nothing is wrong | NULL means no book is due a sweep at all. That is silence about the reconciler, not a clean bill of health — compare how `price_lag` and `sweep_lag` grew between two readings. |
+| A large `price_lag` means prices are stale | The shipped metric does not exclude superseded books, whose `reference_price_at` never advances again. Re-measure with `filter (where superseded_at is null)` first. |
 | `VACUUM FULL` during ops/cron | ACCESS EXCLUSIVE lock on the hot table. Use `vacuum (analyze)`. |

--- a/.claude/skills/indexer-db-diag/SKILL.md
+++ b/.claude/skills/indexer-db-diag/SKILL.md
@@ -129,9 +129,21 @@ select count(*) filter (where last_swept_at is null)                    as never
        count(*) filter (where last_swept_at > now() - interval '1 hour') as fresh_1h,
        count(*)                                                         as total
   from inference_markets where last_reconciled_at is not null;
+
+-- THE ONE THAT MEANS SOMETHING: lag over the books the sweep is actually due to visit.
+-- Compare it against the `sweep_lag` above before concluding anything.
+select now() - min(m.last_swept_at) as sweep_lag_actionable, count(*) as books_due
+  from inference_markets m
+ where m.last_reconciled_at is not null and m.superseded_at is null
+   and exists (select 1 from inference_orders o
+                where o.orderbook_address = m.orderbook_address and o.status = 'OPEN');
 ```
 
-Interpretation: one stuck book drives `min()` — but only the count query tells you whether it IS one book. A sweep also waits on `at_head = true` and on there being no pending `raw_events` for that book's `src_address`, so an L2 backlog *can* stall sweeps. Do not assume that link: join the stale books against pending rows for the same `src_address` and measure it. Recorded negative result — on an earlier stage dataset, 2732 of 2901 books stale for over 7 days had no pending rows at all, so the gate was not the cause.
+**`sweep_lag` over all reconciled books is not a health metric.** A book with no `OPEN` order is never re-swept, deliberately: the candidate query in `inference_reconciler.rs` admits a book for sweeping only via `... and exists (select 1 from inference_orders o where ... o.status='OPEN')`, and `run_sweep_step` is gated again on `has_open_orders` — stamping `last_swept_at` for a book with nothing resting would spend `getQueueSize`/`getStats` getters for no work. So `min(last_swept_at)` grows without bound as books finish trading, on every environment, forever. Use `sweep_lag_actionable`; treat the raw `sweep_lag` as a number that only ever moves one way.
+
+Worked example (stage, 2026-09-02): raw `sweep_lag` read **5 days**, and 316 of 522 books had not been swept since the post-wipe catch-up on 08-28 — which looks like a mass stall. Every one of those 316 had **zero** open orders, while the 79 books swept within 20h held 10 between them. `sweep_lag_actionable` over the 10 books actually due: **2m17s**.
+
+Only after that reads badly is the gate worth checking: a sweep also waits on `at_head = true` and on no pending `raw_events` for the book's `src_address`, so an L2 backlog *can* stall it. Do not assume that link either — join the stale books against pending rows for the same `src_address` and measure. Recorded negative result: on an earlier stage dataset 2732 of 2901 books stale for over 7 days had no pending rows at all.
 
 ## L3 — Why is market X not visible?
 
@@ -213,4 +225,5 @@ vacuum (analyze) raw_events;                              -- after a big purge
 | Reading a flat `undecodable` count as harmless background | No longer true since the registry ABIs were loaded: nothing that reaches a scoped `dst` is undecodable by design any more, so any row there is drift. |
 | `permission denied for schema cron` = "the job is missing" | It means the role cannot look. Check `pg_proc` for the procedure first — that IS readable, and its absence is the answer the `cron` query was being asked for. |
 | Matching a `dst` by suffix (`like '%2bf'`) | `dst_address` holds both routing ids and ordinary 64-hex contract addresses; a suffix match catches addresses that merely end the same way. Compare the full `':' \|\| lpad(to_hex(id),64,'0')`, or extract with `right(dst_address,16)`. |
+| Reading `sweep_lag` (`min(last_swept_at)`) as sweep health | It includes books with no `OPEN` orders, which are never re-swept by design, so it only ever grows. Measure over books that have an open order — on stage that was 5 days versus 2m17s for the same database. |
 | `VACUUM FULL` during ops/cron | ACCESS EXCLUSIVE lock on the hot table. Use `vacuum (analyze)`. |

--- a/.claude/skills/staging-diag/SKILL.md
+++ b/.claude/skills/staging-diag/SKILL.md
@@ -18,7 +18,16 @@ PGCONNECT_TIMEOUT=8 psql "$STAGE_DATABASE_URL"
 
 The URL as a psql argument is visible in the host process list — acceptable on a single-user machine; otherwise use `~/.pgpass` or a `PGSERVICE` entry.
 
-Repo docs and the stage config use the pooler host on port **5432** (session mode) — use that for interactive psql. Port 6543 is Supabase's transaction pooler and `sslmode=require` is the Supabase default (general Supabase behavior; not in repo docs).
+Repo docs and the stage config use the pooler host on port **5432** (session mode) — use that for interactive psql. `sslmode=require` is the Supabase default (general Supabase behaviour; not in repo docs).
+
+Session mode has 15 slots and they do run out, including through no fault of yours — a running indexer holds some. The symptom is `FATAL: (EMAXCONNSESSION) max clients reached in session mode - max clients are limited to pool_size: 15`. Port **6543** is the transaction pooler and has its own budget, so rewrite the port rather than waiting:
+
+```bash
+TX=$(printf '%s' "$STAGE_DATABASE_URL" | sed 's#:5432/#:6543/#')   # never echo either URL
+PGCONNECT_TIMEOUT=10 psql "$TX" -c '...'
+```
+
+Transaction mode does not keep session state (no `SET`, no advisory locks held across statements), which none of the queries below need.
 
 ## L1 — Is the indexer receiving events?
 
@@ -51,7 +60,24 @@ select event_type, count(*), min(chain_order)
 select count(*) as undecodable, max(created_at) as latest from raw_events where event_type is null;
 ```
 
-Interpretation: backlog growing with old `oldest_pending` = projection loop stuck/slow — check indexer logs at the `min(chain_order)` row. A jump in `undecodable` after a contract upgrade = decoder ABI drift (those rows are never projected and never counted in backlog).
+Interpretation: backlog growing with old `oldest_pending` = projection loop stuck/slow — check indexer logs at the `min(chain_order)` row.
+
+**Any undecodable row means ABI drift — there is no benign background.** Every contract that emits to a scoped `dst` has its ABI loaded into the decoder (`DEX_ABIS` + `INFERENCE_ABIS`, twelve of them, `RootModel` and `SuperRoot` included). Of the ABIs that ship unloaded, `ModelRegistry` declares no events at all and `Multisig` is a wallet outside the ingest scope, so neither can put a row here. A non-zero count therefore means the decoder no longer matches the deployed contracts: rebuild and redeploy.
+
+This is a recent sharpening. Until the registry ABIs were loaded, most undecodable rows were ordinary `RootModel`/`SuperRoot` events and a steady background WAS normal — on stage it was the entire undecodable population, 1058 rows. Text written against that era reads a flat count as harmless; it no longer is.
+
+Undecodable rows are also never projected, never counted in the backlog above, and — because `processed_at` stays NULL forever — permanently out of the pruner's reach. Identify the contract before reporting a count:
+
+```sql
+-- Group by the routing id, not the raw address. dst_address holds `:` + 64 zero-padded
+-- hex digits, so right(...,16) is the id; a suffix LIKE would also match ordinary
+-- contract addresses that happen to end in the same digits.
+select ('x' || right(dst_address, 16))::bit(64)::bigint as dst_id,
+       count(*), min(created_at)::date as first, max(created_at)::date as last
+  from raw_events where event_type is null group by 1 order by 2 desc limit 15;
+```
+
+Name the id from the `EVENT_ID` constants in `contracts/*/modifiers/modifiers.sol` — the same set `crates/infrastructure/tests/ingest_scope.rs` re-derives. An id that resolves to a loaded contract, yet decodes to nothing, is a signature-id collision needing a `dst` route in `Decoder::new` rather than a rebuild.
 
 **Sweep lag (inference books):**
 
@@ -60,13 +86,23 @@ select now() - min(reference_price_at) as price_lag,
        now() - min(last_swept_at)      as sweep_lag
   from inference_markets where last_reconciled_at is not null;
 
+-- There is no error-text column. `inference_markets` records only THAT a reconcile
+-- failed (last_reconcile_failed_at) and how often it was retried; the reason is in the
+-- indexer log at that timestamp.
 select orderbook_address, last_swept_at, sweep_cursor, reconcile_attempts,
-       last_reconcile_failed_at, last_reconcile_error
+       last_reconcile_failed_at, sweep_cycle_max, sweep_override_seq
   from inference_markets where last_reconciled_at is not null
  order by last_swept_at asc nulls first limit 5;
+
+-- min() hides how wide the staleness is. Check the shape before blaming one book.
+select count(*) filter (where last_swept_at is null)                    as never_swept,
+       count(*) filter (where last_swept_at < now() - interval '7 days') as older_7d,
+       count(*) filter (where last_swept_at > now() - interval '1 hour') as fresh_1h,
+       count(*)                                                         as total
+  from inference_markets where last_reconciled_at is not null;
 ```
 
-Interpretation: one stuck book drives `min()`. A sweep also waits on `at_head = true` and no pending raw_events for that book's `src_address` — so an L2 backlog stalls sweeps too.
+Interpretation: one stuck book drives `min()` — but only the count query tells you whether it IS one book. A sweep also waits on `at_head = true` and on there being no pending `raw_events` for that book's `src_address`, so an L2 backlog *can* stall sweeps. Do not assume that link: join the stale books against pending rows for the same `src_address` and measure it. Recorded negative result — on an earlier stage dataset, 2732 of 2901 books stale for over 7 days had no pending rows at all, so the gate was not the cause.
 
 ## L3 — Why is market X not visible?
 
@@ -95,27 +131,42 @@ Interpretation: `last_reconciled_at IS NULL` = invisible to the read API regardl
 
 ## Maintenance — raw_events bloat
 
-Pruning lives in `deploy/sql/prune_raw_events.sql`: a pg_cron job `prune-raw-events` (daily 03:00 UTC) calls `public.prune_raw_events(interval '3 days', 10000)` — batched id-range deletes of **processed** rows older than 3 days, advisory-lock guarded; pending rows are never deleted.
+`deploy/sql/prune_raw_events.sql` describes the intended setup: a pg_cron job `prune-raw-events` (daily 03:00 UTC) calling `public.prune_raw_events(interval '3 days', 10000)` — batched id-range deletes of **processed** rows older than 3 days, advisory-lock guarded, pending rows never touched.
 
-**Read-only checks:**
+That is the repo's intent, not a statement about the database in front of you. **Check that the procedure exists before diagnosing the job**, because the role in `STAGE_DATABASE_URL` can read `pg_proc` but not `cron`:
 
 ```sql
--- NOTE: the count(*) filters are a full scan — can be slow/heavy on a bloated table.
-select pg_size_pretty(pg_total_relation_size('raw_events')) as total,
-       count(*) filter (where processed_at is not null) as processed,
-       count(*) filter (where processed_at is null)     as pending
-  from raw_events;
+-- Step 1. Does the procedure exist at all? Readable by any role.
+select n.nspname, p.proname, p.prokind
+  from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+ where p.proname = 'prune_raw_events';
 
+-- Step 2. Only meaningful if step 1 returned a row. Expect
+-- `ERROR: permission denied for schema cron` — see the interpretation below.
 select jobid, schedule, active from cron.job where jobname = 'prune-raw-events';
 select status, return_message, start_time from cron.job_run_details
  where jobid = (select jobid from cron.job where jobname = 'prune-raw-events')
  order by start_time desc limit 5;
+
+-- Step 3. What pruning would reclaim right now, and the table it would reclaim it from.
+-- This works regardless of steps 1-2 and is the only one of the three that measures
+-- OUTCOME rather than configuration.
+select count(*) as prunable_now from raw_events
+ where processed_at is not null and created_at < now() - interval '3 days';
+
+-- NOTE: the count(*) filters below are a full scan — slow on a bloated table.
+select pg_size_pretty(pg_total_relation_size('raw_events')) as total,
+       count(*) filter (where processed_at is not null) as processed,
+       count(*) filter (where processed_at is null)     as pending
+  from raw_events;
 ```
+
+Interpretation. **Step 1 returning zero rows means the pruner is not installed** — no job can be running, whatever `cron` would have said. That is the state stage was found in on 2026-09-02, with 16330 rows already eligible; the fix is to apply `deploy/sql/prune_raw_events.sql` — which installs the procedure *and* schedules the job — not to hunt for a broken schedule. It has to run as a privileged role (on Supabase, the SQL editor, which runs as `postgres`); the pooler role can neither create the extension nor schedule jobs. See [`docs/deployment.md`](../../../docs/deployment.md) § raw_events retention. `permission denied for schema cron` in step 2 means "cannot check from here", **not** "the job is missing" — confirm through the Supabase dashboard (Database → Cron) or a privileged role. A `prunable_now` that keeps climbing across days is the outcome-level symptom either way.
 
 **Remediation — mutates data, confirm with the user first** (out of scope for pure diagnosis):
 
 ```sql
-call public.prune_raw_events(interval '3 days', 10000);  -- manual prune run
+call public.prune_raw_events(interval '3 days', 10000);  -- only if step 1 found it
 vacuum (analyze) raw_events;                              -- after a big purge
 ```
 
@@ -129,5 +180,8 @@ vacuum (analyze) raw_events;                              -- after a big purge
 | Judging visibility by `approved` | Read API gates on `last_reconciled_at IS NOT NULL` (`markets` and `inference_markets`). |
 | Counting inference books without `superseded_at IS NULL` | Superseded books are excluded from the API and metrics. |
 | "Ingest is broken — no `OrderBook.Queued` / `PMP.StakeAccepted` rows" | Stage drops those types before insert (`config/indexer.stage.supabase.yaml` `ignored_event_types`). |
-| Blaming the dapp scope filter | `indexer.dapp_id` is unset in the stage config — no dapp filtering on stage; edges without `src_dapp_id` are always kept. |
+| "There is no dapp filtering, `indexer.dapp_id` is unset" | The config key is indeed unset, but scoping is not done there: the gateway query itself is parameterised by `src_dapp_id` and pinned to the compile-time `DEX_DAPP_ID`, so ingest is dapp-scoped server-side, at fetch. What the unset key means is only that no *additional* local filter runs. |
+| Reading a flat `undecodable` count as harmless background | No longer true since the registry ABIs were loaded: nothing that reaches a scoped `dst` is undecodable by design any more, so any row there is drift. |
+| `permission denied for schema cron` = "the job is missing" | It means the role cannot look. Check `pg_proc` for the procedure first — that IS readable, and its absence is the answer the `cron` query was being asked for. |
+| Matching a `dst` by suffix (`like '%2bf'`) | `dst_address` holds both routing ids and ordinary 64-hex contract addresses; a suffix match catches addresses that merely end the same way. Compare the full `':' \|\| lpad(to_hex(id),64,'0')`, or extract with `right(dst_address,16)`. |
 | `VACUUM FULL` during ops/cron | ACCESS EXCLUSIVE lock on the hot table. Use `vacuum (analyze)`. |

--- a/.claude/skills/sync-contract-events/SKILL.md
+++ b/.claude/skills/sync-contract-events/SKILL.md
@@ -145,7 +145,7 @@ What breaks, by change kind:
 
 | Change | Symptom | Fix |
 |---|---|---|
-| Event renamed or input **types** changed, repo ABI stale | Signature id unknown to old binary → `DecodeOutcome::UnknownId` → row stored with `event_type IS NULL`, never projected, silent except the `decode_errors`/undecodable counters. Check via staging-diag L2: `select count(*) from raw_events where event_type is null;` | Sync the ABI, rebuild, redeploy. Undecodable rows stay undecoded (no auto re-decode). |
+| Event renamed or input **types** changed, repo ABI stale | Signature id unknown to old binary → `DecodeOutcome::UnknownId` → row stored with `event_type IS NULL`, never projected, silent except the `decode_errors`/undecodable counters. Check via indexer-db-diag L2: `select count(*) from raw_events where event_type is null;` | Sync the ABI, rebuild, redeploy. Undecodable rows stay undecoded (no auto re-decode). |
 | Field **renamed** (ABI synced, projector stale) | Projector `.get("oldField")` misses → deterministic projection error → row retried forever via per-row savepoints → L2 backlog grows | Update the `apply_*` fn field names. |
 | New ABI's signature id **collides** with an existing one | `AmbiguousCollision` warn, row left undecoded | Add a dst route in `Decoder::new` (`add_route` with the modifiers.sol EVENT_ID). |
 | Event **removed** / no longer emitted | Nothing breaks; dead arms and enum variants linger | Optional cleanup; precedent: `OB_EPOCH_SETTLED = 145` kept in `modifiers.sol`, intentionally omitted from `order_book_events.rs`. |


### PR DESCRIPTION
Two of this skill's queries could not run at all, and three of its claims were inverted by #154 this week. Both classes are the same failure: a runbook that is read far more often than it is executed drifts silently, and the reader discovers it mid-incident.

Every SQL statement in the file was executed against stage before this was committed — 14 run clean, 3 carry `<placeholder>` values, and 3 are the ones the file now explicitly documents as expected to fail. Zero unexpected failures.

---

## Queries that could not run

**`last_reconcile_error` does not exist.** The L3 sweep-detail query selected it; `inference_markets` has `last_reconcile_failed_at` and no error-text column at all. Anyone copying that query got a syntax error instead of a diagnosis. Replaced with `sweep_cycle_max, sweep_override_seq`, plus a comment saying where the reason actually lives (the indexer log at that timestamp) so the next reader does not go looking for the column again.

**The whole pruning section described a database that isn't there.** It asserted a pg_cron job as fact and led with two `cron.*` queries. On stage:

| Check | Result |
|---|---|
| `prune_raw_events` in `pg_proc` | **0 rows — the procedure does not exist** |
| `cron` schema visible to the `indexer` role | no: `ERROR: permission denied for schema cron` |
| rows already eligible for pruning | 16330 |

So the reader hits `permission denied`, concludes "cannot check from here", and never learns the procedure was never installed. The order is now inverted: `pg_proc` first (readable by any role, and its absence is the answer the `cron` query was being asked for), `cron` second with the expected error spelled out, and third an outcome query — `prunable_now` — that works regardless of the other two and measures the thing that actually matters.

## Claims #154 inverted

Loading the `RootModel` and `SuperRoot` ABIs changed what an undecodable row means, in the direction that makes the signal *stronger*:

- **Before:** those two contracts emitted to scoped `dst`s with no ABI loaded, so a steady background of `event_type IS NULL` was normal. On stage it was the entire undecodable population, 1058 rows.
- **Now:** every contract that emits to a scoped `dst` has its ABI loaded. Of the ABIs that ship unloaded, `ModelRegistry` declares no events at all and `Multisig` is outside the ingest scope. **Any undecodable row is drift.** Stage has held at zero since the deploy.

The old text said a *jump* after a contract upgrade means drift, which reads as "a flat count is fine". That is now exactly backwards, so it is called out in the text and again in Common mistakes — a reader working from memory of the old rule will under-react.

Also added: how to identify one before reporting a count, grouping by `right(dst_address,16)` rather than the raw address, and why a suffix `LIKE` is wrong (`dst_address` holds both routing ids and ordinary 64-hex contract addresses, so `like '%2bf'` also matches addresses that merely end the same way — this produced 4912 rows against a true 4885 while diagnosing the phantom deals).

## Other corrections

**"There is no dapp filtering."** Common mistakes said `indexer.dapp_id` is unset, therefore nothing is dapp-scoped. The premise is right and the conclusion is wrong: the gateway query is parameterised by `src_dapp_id` and pinned to the compile-time `DEX_DAPP_ID`, so ingest *is* dapp-scoped, server-side at fetch. The unset key only means no additional local filter runs. I nearly drew the wrong conclusion from this row while answering the rewards team about prod's empty `markets` table.

**Sweep staleness needs its shape measured.** `min(last_swept_at)` cannot distinguish one stuck book from a general stall. Added a bucket-count query and a recorded negative result: on an earlier stage dataset 2732 of 2901 books stale for over 7 days had no pending rows at all, so the pending-rows gate — the obvious suspect — was not the cause.

**Session-pool exhaustion.** `FATAL: (EMAXCONNSESSION) max clients reached in session mode` hit twice during this week's diagnosis; a running indexer holds some of the 15 slots. Documented the port-6543 rewrite as the way through, with the caveat that transaction mode keeps no session state (none of these queries need it).

## Supersedes an unmerged branch

`fix/staging-diag-skill-drift` (`9b0aed3`) should be dropped rather than merged. Its live fixes are carried here; the rest is now wrong — it states that four ABIs including `RootModel` and `SuperRoot` are deliberately unloaded and their events "undecodable by design", and it edits `sync-contract-events/SKILL.md` in a way that would revert the correction #154 already made there.

`sync-contract-events` needs nothing: its ABI list, its `== 83` count pins and the `decoder.rs:322`/`:344` line references all match the current code exactly.

No `CHANGELOG.md` entry — this is agent tooling, not a surface a DEX.DO operator or integrator can observe.

---

## Second commit: renamed to `indexer-db-diag`, now covers prod read-only

The skill was stage-only by name, by description and by credential. Its `description` is what makes it trigger, so it would not have fired on a prod incident — and the name would have been a lie if it had.

The schema is provably identical (both environments at migration 5), so **every query is shared verbatim**; nothing is duplicated. What is environment-specific is interpretation, and that is now one table plus four notes rather than a second copy of the runbook. Two skills were considered and rejected: this PR's first commit exists because one copy drifted, and the halves that would drift fastest are exactly the interpretations.

**Prod is read-only, stated three times where it matters** — in the environment table, in prose next to it, and on the Remediation heading. `call prune_raw_events(...)` and `vacuum` are real operations against live data and no diagnosis needs them.

Four readings where the honest answer on one environment is an incident on the other are now called out: an old `ingest_age` (mainnet is nearly idle — a gateway query from a 2026-08-01 cursor returns a single event), an empty `markets` (no prediction markets are deployed to mainnet), `undecodable > 0`, and remediation.

### What pointing the skill at prod immediately found

Running its own L2 query against prod for the first time:

| | prod | stage |
|---|---|---|
| `raw_events` | 31181 | 21821 |
| **undecodable** | **31090 (99.7%)** | 30 |
| `prune_raw_events` in `pg_proc` | **0** | **0** |

31085 of those sit on dst 101 (`RootPN.PrivateNoteDeployed`), every one ingested 2026-08-20 by the initial backfill. The same id decodes cleanly on stage — 678 of 678 — so this is not a missing ABI: those bodies carry a signature id from an older contract generation. There is no re-decode path, so they will never project, never get `processed_at`, and never become prunable. On a database that also has no pruner installed, that is 99.7% of the table pinned permanently.

This is recorded in the skill as the prod-specific caveat to the "any undecodable row is drift" rule (judge prod by date, not by total), and it needs a decision of its own outside this PR.

### Verification

Every SQL statement in the file was executed against **both** environments after the rename: 14 run clean on each, 3 carry `<placeholder>` values, 3 are the cron/remediation statements the file documents as not-to-run. Zero failures on either side. All three markdown tables checked for column consistency.

`sync-contract-events` had the one cross-reference to the old name; updated.

---

## Third commit: `sweep_lag` is not a health metric

Found by running the skill against stage rather than reading it. Raw `sweep_lag` reported **5 days**, and 316 of 522 books had not been swept since the post-wipe catch-up on 08-28 — the shape of a mass stall.

It was not one. Every one of those 316 books had **zero** `OPEN` orders; the 79 books swept within 20h held 10 between them. A book with nothing resting is never re-swept, deliberately: the candidate query in `inference_reconciler.rs` admits a book for sweeping only via `and exists (select 1 from inference_orders o where ... o.status='OPEN')`, and `run_sweep_step` is gated again on `has_open_orders`, because stamping `last_swept_at` for an empty book would spend `getQueueSize`/`getStats` getters for no work.

So `min(last_swept_at)` over all reconciled books grows without bound as books finish trading — on every environment, forever. It cannot go down. The skill previously said "one stuck book drives `min()`" and sent the reader to the pending-rows gate; the dominant cause was a third thing it did not mention, and I spent three queries rediscovering it.

Added `sweep_lag_actionable`, scoped to books that actually have an open order. Same database, same moment:

| | value |
|---|---|
| `sweep_lag` (all reconciled books) | 5 days |
| `sweep_lag_actionable` (10 books due) | **2m17s** |

Plus the worked example and a Common mistakes row. The pending-rows gate is still documented, demoted to what it is: worth checking only after the actionable number reads badly.

Re-verified after the addition — 15 statements now, clean on both stage and prod, zero failures.

---

## Fourth commit: telling an idle sweep from a dead reconciler

The third commit made `sweep_lag_actionable` the number to trust. Running the skill against prod exposed its blind spot immediately: prod has **no `OPEN` orders at all**, so `books_due = 0` and the query returns `NULL`. That is the correct answer to "how stale are the books due a sweep" and no answer whatsoever to "is the reconciler running" — which on a quiet mainnet is the question you actually have.

The pair of lags answers it, and the reason is structural rather than incidental. Queue B's candidate predicate (`select_refresh_books_scoped`) is an OR of two independent due-conditions:

```
(reference_price_at is null or reference_price_at < now() - reference_price_refresh)
or
((last_swept_at is null or last_swept_at < now() - sweep_interval)
   and exists (select 1 from inference_orders o where ... o.status = 'OPEN'))
```

The `OPEN`-order gate hangs on the **sweep half only**. An idle book is still visited on the price half every refresh interval; it just leaves `last_swept_at` alone. So the loop turning and the sweep standing still is the designed steady state, and the two lags diverging is the proof the loop is turning.

Measured on prod, 2026-09-02, two readings ~1h36m apart:

| | growth | absolute |
|---|---|---|
| `sweep_lag` | +1h36m — the full elapsed time | `last_swept_at` spans 08-25 … 08-31 |
| `price_lag` | +9m35s | all 8 books priced within the past hour |

Both growing by the elapsed time is the failure reading, and it now has a row in the table.

### A second flaw found on the way

`price_lag` has the same defect `sweep_lag` does, one layer down. The shipped metric `indexer_inference_reference_price_lag_seconds` (`inference_staleness_seconds`, `indexer_repo.rs`) takes `min(reference_price_at)` over `last_reconciled_at is not null` and does **not** exclude superseded books — but the refresh candidate query *does* exclude them. A superseded book's price timestamp therefore freezes and pins the metric upward permanently, exactly as retired books pin `sweep_lag`.

Stated in the skill as structural, not as an observation: both environments held **zero** superseded books when checked, so there is nothing to measure yet. The correcting query is included so the reader can rule it out in one statement rather than rediscovering it. Whether the metric itself should carry `and superseded_at is null` is a separate call and not made here.

### Verification

21 SQL statements now; 17 executed against **both** stage and prod, zero failures on either (the other 4 are the two `cron.*` statements the file documents as expected to fail and the two mutating remediation statements). All four markdown tables checked for column consistency. Prod was read-only throughout — `select` only.
